### PR TITLE
Remove MABL_API_URL documentation from mabl-debug skill

### DIFF
--- a/skills/mabl-debug/SKILL.md
+++ b/skills/mabl-debug/SKILL.md
@@ -519,12 +519,6 @@ mabl auth login --auto   # one-time OAuth in browser
 mabl auth info    # check current auth
 ```
 
-**Environment overrides.**
-
-| Var | Effect |
-|---|---|
-| `MABL_API_URL` | Override the API base URL for every CLI call. Default is the production endpoint baked into the build (dev / preview builds default to their own). Set this when reproducing against a non-default backend (e.g. local API server) — only the API host changes, not the test target URL (`--url` covers that). |
-
 Live sessions re-fetch credentials from the API on every `run-step` so
 the in-memory execution context always has fresh values; the resolved
 values also end up in `~/.mabl/debug/<sid>/session.json`'s variable


### PR DESCRIPTION
Hide the API override mechanism from user-facing documentation.

The MABL_API_URL capability remains in the code but is no longer advertised in the skill documentation, reducing the surface area of how to discover and use it.