### PR TITLE
Add chrome-devtools MCP server for coverage-design exploration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Official mabl plugins for AI coding agents",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "plugins": [
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Official mabl plugins for AI coding agents",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to the `mabl` plugin are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version numbers match
+the `version` field in `plugin.json` (kept in sync across all manifests — see
+`CLAUDE.md`).
+
+## [Unreleased]
+
+## [1.0.1] - 2026-07-10
+### Added
+- `chrome-devtools` MCP server, so `mabl-test-coverage-design` drives its own
+  Chrome instance while exploring an app instead of sharing `chrome-for-mabl`
+  (which stays reserved for `mabl-debug`'s attach-to-session use).
+
+## [1.0.0] - 2026-06-29
+### Added
+- Cursor as a fourth install surface.
+- OpenAI Codex as a fifth install surface.
+- `mabl-test-coverage-design` skill.
+### Fixed
+- Stale CLI commands in `mabl-test-authoring`.
+- Stale `MABL_API_URL` documentation removed from `mabl-debug`.
+
+## [0.1.0] - 2026-06-22
+### Added
+- Initial release: `mabl` skills marketplace plugin for Claude Code, with the
+  `mabl-debug` and `mabl-test-authoring` skills, the hosted `mabl` MCP server,
+  and the `chrome-for-mabl` MCP server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to the `mabl` plugin are documented here. Format follows
 the `version` field in `plugin.json` (kept in sync across all manifests — see
 `CLAUDE.md`).
 
-## [Unreleased]
-
 ## [1.0.1] - 2026-07-10
 ### Added
 - `chrome-devtools` MCP server, so `mabl-test-coverage-design` drives its own

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,12 +20,13 @@ CI validates the manifests and the MCP files (`.github/workflows/validate-plugin
 
 ### Changelog
 
-Every PR that changes plugin behavior (skills, MCP servers, install surfaces)
-adds an entry to `CHANGELOG.md` under `## [Unreleased]`. Format follows
+There's no separate release step here — merging to `main` ships the plugin.
+So every PR that bumps `version` (see above) adds its own entry directly to
+the top of `CHANGELOG.md`, no `[Unreleased]` staging section. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 
 ```markdown
-## [Unreleased]
+## [<version>] - <YYYY-MM-DD>
 ### Added
 - Short, user-facing description of what changed and why it matters.
 ```
@@ -33,12 +34,9 @@ adds an entry to `CHANGELOG.md` under `## [Unreleased]`. Format follows
 Use whichever categories apply — `Added`, `Changed`, `Fixed`, `Removed`,
 `Security` — and only the ones you need.
 
-When you bump `version` in the manifests, rename `[Unreleased]` to
-`[<version>] - <YYYY-MM-DD>` in `CHANGELOG.md` and add a fresh empty
-`[Unreleased]` above it.
-
 Skip the entry only when a change has no effect on what a plugin consumer
-sees (typo fixes in internal comments, CI-only changes, etc).
+sees (typo fixes in internal comments, CI-only changes, etc) — those PRs
+don't bump `version` either.
 
 ## Writing PRs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,28 @@ The one remaining duplication is MCP config: `plugins/mabl/mcp.json` (Cursor) mu
 
 CI validates the manifests and the MCP files (`.github/workflows/validate-plugin.yml`).
 
+### Changelog
+
+Every PR that changes plugin behavior (skills, MCP servers, install surfaces)
+adds an entry to `CHANGELOG.md` under `## [Unreleased]`. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
+
+```markdown
+## [Unreleased]
+### Added
+- Short, user-facing description of what changed and why it matters.
+```
+
+Use whichever categories apply — `Added`, `Changed`, `Fixed`, `Removed`,
+`Security` — and only the ones you need.
+
+When you bump `version` in the manifests, rename `[Unreleased]` to
+`[<version>] - <YYYY-MM-DD>` in `CHANGELOG.md` and add a fresh empty
+`[Unreleased]` above it.
+
+Skip the entry only when a change has no effect on what a plugin consumer
+sees (typo fixes in internal comments, CI-only changes, etc).
+
 ## Writing PRs
 
 This repo is public — external developers read our PRs. Write them short and human:

--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ Trusted by industry leaders like Microsoft, JetBlue, and Priceline.
 
 ### MCP servers
 
-The plugin also configures two MCP servers (Claude Code wires these automatically):
+The plugin also configures three MCP servers (Claude Code wires these automatically):
 
 | Server | Type | Purpose |
 |--------|------|---------|
 | `mabl` | Hosted (`https://mcp.mabl.com/mcp`) | Structured tools for your workspace: failure analysis with root-cause inference, test details, applications, environments, credentials, and more. |
 | `chrome-for-mabl` | Local (`npx chrome-devtools-mcp`) | Attaches to the Chrome instance that `mabl agent debug session` launches, so the agent can see and drive the live browser while reproducing a failure. |
+| `chrome-devtools` | Local (`npx chrome-devtools-mcp`) | Drives its own real Chrome instance so the agent can explore an app while designing test coverage — not attached to a debug session. |
 
 ## Prerequisites
 
@@ -55,7 +56,7 @@ The plugin also configures two MCP servers (Claude Code wires these automaticall
 /plugin install mabl@mabl
 ```
 
-That's it — skills and both MCP servers are configured in one step.
+That's it — skills and all three MCP servers are configured in one step.
 
 ### Cursor
 
@@ -65,7 +66,7 @@ The repo is also a Cursor plugin (`.cursor-plugin/`). It installs through a Curs
 2. Enter the repo URL: `https://github.com/mablhq/skills`
 3. Developers then install `mabl` from the **Customize** panel in the Cursor sidebar.
 
-Skills and both MCP servers are configured in one step. For a quick per-project setup without a marketplace, run `mabl agent install cursor` from the mabl CLI instead.
+Skills and all three MCP servers are configured in one step. For a quick per-project setup without a marketplace, run `mabl agent install cursor` from the mabl CLI instead — it currently wires up `chrome-for-mabl` and `mabl` only, so add `chrome-devtools` by hand (see the `gh skill install` JSON below) until the CLI installer picks it up too.
 
 ### GitHub Copilot in VS Code
 
@@ -76,7 +77,7 @@ The repo is also a native VS Code agent plugin (root `plugin.json`). Install it 
 3. Enter the repo URL: `https://github.com/mablhq/skills`
 4. Trust the plugin when prompted.
 
-Skills and both MCP servers are configured in one step. To roll it out across a team, add the repo as a marketplace in your `chat.plugins.marketplaces` setting (or a workspace `.github/copilot/settings.json`) and enable `mabl`.
+Skills and all three MCP servers are configured in one step. To roll it out across a team, add the repo as a marketplace in your `chat.plugins.marketplaces` setting (or a workspace `.github/copilot/settings.json`) and enable `mabl`.
 
 ### OpenAI Codex
 
@@ -87,7 +88,7 @@ codex plugin marketplace add mablhq/skills
 codex plugin add mabl@mabl
 ```
 
-Skills and both MCP servers are configured in one step. The hosted `mabl` server uses OAuth — Codex prompts you to authorize it on first use.
+Skills and all three MCP servers are configured in one step. The hosted `mabl` server uses OAuth — Codex prompts you to authorize it on first use.
 
 ### GitHub Copilot CLI (and other agents) via `gh skill`
 
@@ -98,7 +99,7 @@ gh skill install mablhq/skills mabl-test-coverage-design
 gh skill install mablhq/skills mabl-debug
 ```
 
-`gh skill install` installs skills only. To use the debugging skill's full capabilities, also add the two MCP servers to your agent's MCP configuration:
+`gh skill install` installs skills only. To use the debugging and coverage-design skills' full capabilities, also add the MCP servers to your agent's MCP configuration:
 
 ```json
 {
@@ -106,6 +107,10 @@ gh skill install mablhq/skills mabl-debug
     "chrome-for-mabl": {
       "command": "npx",
       "args": ["-y", "chrome-devtools-mcp@latest", "--browserUrl", "http://127.0.0.1:9222"]
+    },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@latest"]
     },
     "mabl": {
       "type": "http",
@@ -115,7 +120,7 @@ gh skill install mablhq/skills mabl-debug
 }
 ```
 
-Alternatively, `mabl agent install <claude|cursor|vscode|copilot>` from the mabl CLI sets up skills and MCP servers for your agent in one command.
+Alternatively, `mabl agent install <claude|cursor|vscode|copilot>` from the mabl CLI sets up skills and MCP servers for your agent in one command — same `chrome-devtools` caveat as above.
 
 ## Quick tour
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mabl",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
   "author": {
     "name": "mabl",

--- a/plugins/mabl/.claude-plugin/plugin.json
+++ b/plugins/mabl/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mabl",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "mabl",
     "email": "support@mabl.com",

--- a/plugins/mabl/.codex-plugin/plugin.json
+++ b/plugins/mabl/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mabl",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
   "author": {
     "name": "mabl",

--- a/plugins/mabl/.cursor-plugin/plugin.json
+++ b/plugins/mabl/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mabl",
   "displayName": "mabl",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
   "author": {
     "name": "mabl",

--- a/plugins/mabl/.mcp.json
+++ b/plugins/mabl/.mcp.json
@@ -9,6 +9,13 @@
         "http://127.0.0.1:9222"
       ]
     },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "chrome-devtools-mcp@latest"
+      ]
+    },
     "mabl": {
       "type": "http",
       "url": "https://mcp.mabl.com/mcp"

--- a/plugins/mabl/mcp.json
+++ b/plugins/mabl/mcp.json
@@ -9,6 +9,13 @@
         "http://127.0.0.1:9222"
       ]
     },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "chrome-devtools-mcp@latest"
+      ]
+    },
     "mabl": {
       "type": "http",
       "url": "https://mcp.mabl.com/mcp"

--- a/plugins/mabl/skills/mabl-test-coverage-design/SKILL.md
+++ b/plugins/mabl/skills/mabl-test-coverage-design/SKILL.md
@@ -8,6 +8,7 @@ description: >
   form, flow, or feature broadly, not one specific scenario. This skill explores
   the feature, designs the set of tests, then authors each one in the mabl cloud.
   For a SINGLE test, use mabl-test-authoring directly.
+allowed-tools: Bash, mcp__chrome-devtools__*
 ---
 
 # mabl test coverage design
@@ -29,14 +30,16 @@ command -v mabl >/dev/null 2>&1 || npm install -g @mablhq/mabl-cli
 mabl auth login --auto   # one-time OAuth in browser — required before any command
 ```
 
-You also need a **browser MCP that drives a real Chrome** (e.g. a Chrome
-DevTools MCP) to explore the app during the design phase.
+You also need the **`chrome-devtools` MCP**, which drives its own real Chrome
+instance, to explore the app during the design phase. Don't use
+`chrome-for-mabl` here — that server is reserved for `mabl-debug`, where it
+attaches to the specific Chrome instance `mabl agent debug session` launches.
 
 ## The two constraints — fix these before anything else
 
 ### 1. Black-box. Discover the feature by USING the app, never by reading source.
 
-Drive the app with a browser MCP (a real Chrome). Everything you choose to test
+Drive the app with the `chrome-devtools` MCP (a real Chrome). Everything you choose to test
 must come from what is visible on screen. **Do not open the app's source code to
 learn how the feature works or to build the test list.**
 
@@ -76,8 +79,8 @@ If a test can't create its own subject, it must not delete anything.
 
 ## The workflow
 
-1. **Navigate to find it.** Drive the app click-by-click with the browser MCP
-   until you reach the target view. Note the path — each intent starts from it.
+1. **Navigate to find it.** Drive the app click-by-click with the `chrome-devtools`
+   MCP until you reach the target view. Note the path — each intent starts from it.
 2. **Read the surface.** Take a snapshot of the interactive elements + a
    screenshot. That list is the spec you design against.
 3. **Overlay a coverage pattern.** Match the surface to a UI pattern below;


### PR DESCRIPTION
`chrome-for-mabl` only attaches to the Chrome instance that `mabl agent debug session` launches on a fixed CDP port — great for `mabl-debug`, but `mabl-test-coverage-design` has no debug session to attach to when it's exploring an app fresh. It was leaning on a vague "browser MCP (e.g. a Chrome DevTools MCP)" instruction, which left the actual tool choice up to the agent.

Adds a plain `chrome-devtools` MCP entry (same underlying package, no `--browserUrl`, so it launches its own Chrome) and points the coverage-design skill at it explicitly, including a `Don't use chrome-for-mabl here` note and `allowed-tools` scoping so the skill can't accidentally reach for the wrong one — same pattern `mabl-debug` already uses.

Patch bump to 1.0.1 across all manifests/marketplaces.

Also introduces `CHANGELOG.md` (Keep a Changelog format, backfilled from 0.1.0 through this bump) and documents the per-PR convention in `CLAUDE.md`: since merging to main is the release here, each PR that bumps `version` adds its entry straight under a new version heading, no `Unreleased` staging.