### PR TITLE
Make serial the default suite strategy in coverage-design, drop seed

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Official mabl plugins for AI coding agents",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "plugins": [
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Official mabl plugins for AI coding agents",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the `mabl` plugin are documented here. Format follows
 the `version` field in `plugin.json` (kept in sync across all manifests — see
 `CLAUDE.md`).
 
+## [1.0.2] - 2026-07-15
+### Changed
+- `mabl-test-coverage-design` now defaults to authoring a suite **serially** —
+  the central happy-path test first, then each later test referencing all the
+  siblings before it — so the suite converges on one consistent shape.
+### Removed
+- The `seed` suite-strategy mode. `serial` already is the seed, so the hybrid
+  mode was redundant; `parallel` remains for when speed matters more than
+  consistency.
+
 ## [1.0.1] - 2026-07-10
 ### Added
 - `chrome-devtools` MCP server, so `mabl-test-coverage-design` drives its own

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,15 @@ Why a subdirectory and not the repo root? **Codex.** Its marketplace requires ea
 - **GitHub Copilot / VS Code plugin** (`mabl`) — manifest is the **root `plugin.json`**, because VS Code's plugin loader checks for a manifest at the repo root. It points into the home: `"skills": "plugins/mabl/skills/"`, `"mcpServers": "plugins/mabl/.mcp.json"`.
 - **`gh skill install` source** — skills discovered via the `skills/*/SKILL.md` convention, which `gh skill` finds even nested under a prefix (`plugins/mabl/skills/...`).
 
+### Changing a skill? Bump the version and update the docs
+
+When you change something a plugin consumer sees — a skill's behavior, a new or
+removed skill, an MCP server — **bump `version`** (all manifests; see "Keep the
+manifests and MCP files in sync" below), add a `CHANGELOG.md` entry (see
+"Changelog" below), and refresh the skill's row in `README.md` if what it does
+changed. Skip all three only for changes no consumer ever sees (internal
+comments, CI-only tweaks).
+
 ### Keep the manifests and MCP files in sync
 
 The four plugin manifests — `plugins/mabl/.claude-plugin/plugin.json`, `plugins/mabl/.cursor-plugin/plugin.json`, `plugins/mabl/.codex-plugin/plugin.json`, and the root `plugin.json` (Copilot) — describe the same plugin. When you bump `version` or change `name`/`description`/`author`, update **all four** (and the `version` in the three `marketplace.json` files, which isn't parity-checked). CI checks this parity.

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mabl",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
   "author": {
     "name": "mabl",

--- a/plugins/mabl/.claude-plugin/plugin.json
+++ b/plugins/mabl/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mabl",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "mabl",
     "email": "support@mabl.com",

--- a/plugins/mabl/.codex-plugin/plugin.json
+++ b/plugins/mabl/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mabl",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
   "author": {
     "name": "mabl",

--- a/plugins/mabl/.cursor-plugin/plugin.json
+++ b/plugins/mabl/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mabl",
   "displayName": "mabl",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
   "author": {
     "name": "mabl",

--- a/plugins/mabl/skills/mabl-test-coverage-design/SKILL.md
+++ b/plugins/mabl/skills/mabl-test-coverage-design/SKILL.md
@@ -99,7 +99,9 @@ If a test can't create its own subject, it must not delete anything.
    constraints → navigation path → observed surface → pattern overlay → chosen
    tests + what was dropped.
 8. **Fan out.** Author each intent with `mabl agent authoring` (below), using
-   the strategy (default `seed`). Report each `createdTestId` + `viewTestUrl`.
+   the strategy (default `serial`). Order the intents so the central happy-path
+   test is authored first — it seeds every test after it. Report each
+   `createdTestId` + `viewTestUrl`.
 
 ## Authoring each test
 
@@ -119,25 +121,27 @@ The `mabl-test-authoring` skill covers this command in depth (the
 `--test-information` fields, API tests, local mode). Use it for the per-test
 detail; this skill owns deciding *which* tests to author and *in what order*.
 
-## Suite strategy — parallel, seed, or chain
+## Suite strategy — serial or parallel
 
 How the tests get authored relative to each other. Pick a mode; default to
-`seed`. The user may override ("author them in parallel", "chain them").
+`serial`. The user may override ("author them in parallel").
 
 | Mode | Behavior | Wall-clock | Use when |
 |---|---|---|---|
+| `serial` (default) | author sequentially, central happy-path first; each test references **all** prior siblings (plus any existing team tests) | ~N tests | default — the first test seeds the rest and every test after it builds on what already worked |
 | `parallel` | author all intents at once, independently | ~1 test | speed matters; consistency comes from existing team tests (reference those) |
-| `seed` (default) | author the anchor test first (the central happy-path), wait for it, then fan out the rest **concurrently**, each referencing the anchor | ~2 tests | greenfield suite; want a consistency anchor without paying full serialization |
-| `chain` | author sequentially; each test references **all** prior siblings | ~N tests | max consistency, order matters, no existing references to anchor on |
 
-Each cloud authoring run takes 5–20 min, so `chain` of N tests ≈ N× the
-wall-clock of `parallel`. Prefer `seed` unless the user asks otherwise.
+`serial` is the default because it *is* the seed: the central happy-path test
+is authored first, and every test after it references all the siblings already
+created, so the suite converges on one shape. Each cloud authoring run takes
+5–20 min, so `serial` of N tests ≈ N× the wall-clock of `parallel` — switch to
+`parallel` only when speed matters more than consistency and the user says so.
 
 **Degrade gracefully — these runs are slow and can fail or time out.** One
 failed authoring run must not abort the rest: keep going and report which tests
-succeeded (with `createdTestId`) and which failed, so the run is resumable. If
-the `seed` anchor fails, don't block the suite — fall back to `parallel` for the
-remaining tests (they just author without an anchor reference).
+succeeded (with `createdTestId`) and which failed, so the run is resumable. In
+`serial`, if one test fails, don't block the suite — continue to the next test,
+referencing the siblings that did succeed (skip the failed one's ID).
 
 ### How a test references another
 
@@ -150,7 +154,8 @@ verbatim except the IDs:
 ```
 [Reference test context]
 The following tests are related references. Use get_test_definition to study
-them and match their flows, structure, and conventions.
+them and match their flows, structure, and conventions. Trust that structure:
+start from it and change or add only the steps that make THIS test different.
 Reference test IDs: <testId1>, <testId2>
 ```
 
@@ -160,8 +165,9 @@ definition — the same mechanism the mabl web app's "Add reference tests" uses.
 - **Prefer existing team tests as references** whenever the workspace has good
   related ones — they're higher-signal than a freshly-generated sibling. Include
   their IDs in the block in any mode, even `parallel`.
-- In `seed`/`chain`, collect each `createdTestId` as authoring completes and feed
-  it into the reference block of the tests authored after it.
+- In `serial`, collect each `createdTestId` as authoring completes and feed all
+  the prior created IDs into the reference block of the next test, so each test
+  sees every sibling built before it.
 
 ## Coverage patterns (the question sets)
 


### PR DESCRIPTION
The coverage-design skill had three suite modes — `parallel`, `seed`, and `chain`. `seed` was a hybrid ("author an anchor, then fan out concurrently") that stopped earning its keep once you realize `serial` already *is* the seed: it authors the central happy-path first, and every later test references all the siblings before it, so the suite converges on one shape without a separate anchor-then-fan-out mode.

So: dropped `seed`, made `serial` the default, kept `parallel` as the speed escape-hatch. The tradeoff is honest in the doc — serial is N× the wall-clock of parallel, so reach for parallel when speed matters more than consistency.

Also nudged the cloud planner via the reference-test block: trust the structure of the reference tests, start from it, and only change the steps that make each test different — instead of redesigning the flow from scratch every time.

Bumped to 1.0.2 with a changelog entry, and added a CLAUDE.md reminder to bump the version and update the docs whenever a skill change is consumer-visible (so the bump doesn't get forgotten).