### PR TITLE
Add mabl-init skill for one-time project setup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Official mabl plugins for AI coding agents",
-    "version": "1.0.2"
+    "version": "1.1.0"
   },
   "plugins": [
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Official mabl plugins for AI coding agents",
-    "version": "1.0.2"
+    "version": "1.1.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the `mabl` plugin are documented here. Format follows
 the `version` field in `plugin.json` (kept in sync across all manifests — see
 `CLAUDE.md`).
 
+## [1.1.0] - 2026-07-27
+### Added
+- `mabl-init` skill — one-time project setup that discovers your workspace,
+  applications, environments, and credentials over the `mabl` MCP server and
+  writes them (with resolved deployment URLs and worked create/run examples)
+  into your agent memory file, so later sessions can author and run tests
+  without re-explaining the setup. Auto-detects the memory file per client
+  (`CLAUDE.md` / `AGENTS.md` / Copilot instructions) and never stores secrets.
+
 ## [1.0.2] - 2026-07-15
 ### Changed
 - `mabl-test-coverage-design` now defaults to authoring a suite **serially** —

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Trusted by industry leaders like Microsoft, JetBlue, and Priceline.
 
 | Skill | What it does |
 |-------|--------------|
+| [`mabl-init`](plugins/mabl/skills/mabl-init/SKILL.md) | Set up a project once. Discovers your mabl workspace, applications, environments, and credentials, asks how the agent should pick between them, and writes it all into your agent memory file (`CLAUDE.md` / `AGENTS.md` / Copilot instructions) so every later session knows how to create and run your tests. |
 | [`mabl-test-authoring`](plugins/mabl/skills/mabl-test-authoring/SKILL.md) | Create mabl browser and API tests through conversational planning. Describe what to test in plain language, refine the plan with the mabl AI agent, then generate the test in the mabl cloud — no local browser needed. |
 | [`mabl-test-coverage-design`](plugins/mabl/skills/mabl-test-coverage-design/SKILL.md) | Design a whole suite of mabl tests for a feature, not just one. The agent explores your app like a user (never reading source), maps what it sees onto proven UI-coverage patterns, then authors a set of self-isolating tests in the mabl cloud. |
 | [`mabl-debug`](plugins/mabl/skills/mabl-debug/SKILL.md) | Diagnose and fix mabl test failures. Forensic triage of a failed run (step traces, screenshots, DOM snapshots, network logs, console errors), then live reproduction: the agent re-runs the test step by step in a real Chrome it controls, patches the page or your code, and verifies the fix. |

--- a/README.md
+++ b/README.md
@@ -95,12 +95,13 @@ Skills and all three MCP servers are configured in one step. The hosted `mabl` s
 
 ```bash
 # install the skills into the current project
+gh skill install mablhq/skills mabl-init
 gh skill install mablhq/skills mabl-test-authoring
 gh skill install mablhq/skills mabl-test-coverage-design
 gh skill install mablhq/skills mabl-debug
 ```
 
-`gh skill install` installs skills only. To use the debugging and coverage-design skills' full capabilities, also add the MCP servers to your agent's MCP configuration:
+`gh skill install` installs skills only. The skills also need their MCP servers — `mabl-init` uses the hosted `mabl` server, and the debugging and coverage-design skills also use the `chrome-*` servers — so add them to your agent's MCP configuration:
 
 ```json
 {

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mabl",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
   "author": {
     "name": "mabl",

--- a/plugins/mabl/.claude-plugin/plugin.json
+++ b/plugins/mabl/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mabl",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "author": {
     "name": "mabl",
     "email": "support@mabl.com",

--- a/plugins/mabl/.codex-plugin/plugin.json
+++ b/plugins/mabl/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mabl",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
   "author": {
     "name": "mabl",

--- a/plugins/mabl/.cursor-plugin/plugin.json
+++ b/plugins/mabl/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mabl",
   "displayName": "mabl",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
   "author": {
     "name": "mabl",

--- a/plugins/mabl/skills/mabl-init/SKILL.md
+++ b/plugins/mabl/skills/mabl-init/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: mabl-init
+description: |
+  One-time project setup for mabl. Discover this user's mabl workspace,
+  applications, environments, and credentials over the mabl MCP server, then
+  write everything an AI agent needs to create and run mabl cloud tests into
+  the project's agent memory file (CLAUDE.md / AGENTS.md /
+  .github/copilot-instructions.md).
+  Fire when the user says "set up mabl", "mabl init", "initialize mabl",
+  "configure mabl for this project", "save my mabl workspace / application /
+  environment / credentials", "add mabl to my CLAUDE.md", or "/mabl-init".
+  Run this once per project, before authoring or running tests. For creating a
+  single test use mabl-test-authoring; for a whole suite use
+  mabl-test-coverage-design.
+allowed-tools: Bash, Read, Write, Edit, mcp__mabl__get_current_user, mcp__mabl__list_mabl_workspaces, mcp__mabl__list_mabl_applications, mcp__mabl__list_mabl_environments, mcp__mabl__list_mabl_credentials
+---
+
+# mabl init
+
+Prime a project so any future agent session can create and run mabl tests with
+no re-explaining. This skill reads your mabl account through the hosted `mabl`
+MCP server, asks you the handful of choices only you can make, and writes a
+`## mabl testing` section into your project's agent memory file.
+
+## Prerequisites
+
+This skill uses the hosted **`mabl` MCP server** (bundled with this plugin) —
+not the mabl CLI. Confirm the server is connected before doing anything else:
+
+- Call `get_current_user`.
+  - **Fails / tool unavailable** → the `mabl` MCP server isn't connected.
+    Tell the user to install and authorize it (see the plugin README —
+    `/plugin install mabl@mabl` for Claude Code, or add the
+    `https://mcp.mabl.com/mcp` server for other agents) and **stop**.
+  - **Succeeds** → remember `defaultWorkspaceId` (the fallback workspace when
+    the user doesn't pick one).
+
+## Workflow
+
+Do these in order. Steps 1–5 gather; step 6 writes.
+
+### 1. Confirm the workspace
+
+Call `list_mabl_workspaces`.
+
+- **One workspace** → use it.
+- **More than one** → show a short numbered list of `name — id` and ask the
+  user which one. Default to `defaultWorkspaceId` from the prerequisite check.
+
+Record the chosen `{id, name}`. Use this `workspaceId` on every call below.
+
+### 2. Discover applications, environments, and URLs
+
+Call `list_mabl_applications` with the `workspaceId`. Each application comes
+back with its `environments[]`, and **each environment carries the deployment
+`url`** — the actual address a test navigates to. This one call gives you apps,
+environments, and URLs together.
+
+Also call `list_mabl_environments` (same `workspaceId`) to catch environments
+that exist but have no deployment yet (these have a name and id but no URL).
+
+Show the user a table: application → environment → URL. This is the raw
+material for the memory file.
+
+One call (default limit 100) is enough for setup — don't chase pagination. A
+`nextCursor` can come back even when everything already fit on the first page,
+so only fetch another page if the workspace genuinely has more than 100 of
+something.
+
+If no applications or environments come back, this workspace isn't set up for
+testing yet. Don't write an empty table — tell the user to add an application
+and a deployment in mabl first (or that tests can still target an ad-hoc URL via
+`urlOverride`), and check they picked the workspace they meant in step 1.
+
+### 3. Decide how to choose an application & environment
+
+- **Exactly one application with one environment** → use it; skip the question.
+- **Otherwise, ask the user how the agent should pick** when there's more than
+  one. Offer these three options and record the answer:
+  - **(a) One default** — choose a default application + environment now. The
+    agent uses it unless told otherwise.
+  - **(b) Folder-based** — map repo folders to app/environment pairs (e.g.
+    `apps/web/**` → Web App / Staging). Gather one pair per relevant folder.
+  - **(c) Ask each time** — no default; the agent asks (or the user names) the
+    app/environment for each test.
+
+### 4. Map credentials
+
+Call `list_mabl_credentials` with the `workspaceId`. You get `id`, `name`,
+`type` (`basic` or `basic_with_totp`), and `cloud_only` — **never secrets**.
+
+Show them and, for each, ask the user for a one-line **"use when…"** note
+(suggest a guess from the name, e.g. "Admin user" → "tests that need admin
+access"; let them accept, edit, or skip). If there are no credentials, note
+that auth-less tests need none.
+
+The file stores each credential's **name, ID, and type** plus your note —
+never a username or password (the MCP server never returns those). A
+credential's *name* can embed a test-account username, and this memory file is
+meant to be committed and shared with your team — so it's fine for IDs and
+names, but never a place for real secrets.
+
+### 5. Pick the memory file for this client
+
+Determine which agent client you are running in (you know your own harness; if
+unsure, check env vars like `CLAUDECODE` or `CURSOR_*`, and look for an existing
+memory file). Map it to the right file at the project root:
+
+| Client | File |
+|--------|------|
+| Claude Code | `./CLAUDE.md` |
+| Cursor | `./AGENTS.md` |
+| GitHub Copilot (VS Code) | `./.github/copilot-instructions.md` |
+| OpenAI Codex | `./AGENTS.md` |
+| Anything else | `./AGENTS.md` (the cross-agent default) |
+
+Tell the user the resolved path and confirm it before writing.
+
+### 6. Write (or merge) the memory section
+
+- **File exists** → `Read` it first. If it already has a `## mabl testing`
+  section, replace just that section. Otherwise append the section. **Never**
+  touch unrelated content.
+- **File doesn't exist** → create it with the section.
+
+Fill in the template below from what you gathered. For "Choosing an
+application & environment", keep only the one block that matches the strategy
+from step 3 — drop the other two and the `<!-- … -->` picker markers (they are
+guides for you, not content for the file).
+
+### 7. Confirm and suggest a next step
+
+Summarize what you saved (workspace, number of apps and credentials, file path)
+and suggest a smoke check, e.g.:
+
+> Try: *"create a mabl test for &lt;a page in your app&gt;"* — I'll use the
+> workspace and app you just configured.
+
+---
+
+## Memory section template
+
+Write this as a `## mabl testing` section. Replace every `<…>` and drop rows /
+blocks that don't apply. Reference mabl tools by their plain names (the agent
+maps them to its own MCP tool names).
+
+```markdown
+## mabl testing
+
+This project uses [mabl](https://www.mabl.com) for end-to-end testing, driven
+through the hosted `mabl` MCP server. To create, run, or debug a mabl test, use
+the mabl MCP tools with the IDs below.
+
+### Workspace
+- **<workspace name>** — `<workspaceId>`
+
+Pass `workspaceId: <workspaceId>` on every mabl MCP call. Call
+`get_current_user` to double-check the active workspace.
+
+### Applications & environments
+
+| Application | Application ID | Environment | Environment ID | URL |
+|-------------|----------------|-------------|----------------|-----|
+| <App name>  | `<app id>`     | <Env name>  | `<env id>`     | <url> |
+
+### Choosing an application & environment
+
+<!-- (a) One default -->
+Default to **<App>** (`<app id>`) on **<Env>** (`<env id>`, <url>) unless I say
+otherwise. The full list is in the table above.
+
+<!-- (b) Folder-based -->
+Pick the app/environment by the folder the work is in:
+- `<glob>` → <App> (`<app id>`) / <Env> (`<env id>`)
+- `<glob>` → <App> (`<app id>`) / <Env> (`<env id>`)
+If a file isn't covered, ask me.
+
+<!-- (c) Ask each time -->
+There are several applications/environments (see the table). Ask me which to
+use before creating or running a test.
+
+### Credentials
+
+Credential names, IDs, and types only — never usernames, passwords, or secrets.
+
+| Credential | ID | Type | Use when |
+|------------|-----|------|----------|
+| <name>     | `<cred id>` | <type> | <use-when note> |
+
+If a test needs no login, omit the credential.
+
+### Create a test
+1. `mabl_authoring_plan` — describe the test in plain language (which app/URL,
+   the steps, what to verify). Refine with the returned session id if needed.
+2. `mabl_authoring_initiate` — generate it in the cloud from that plan.
+3. `mabl_authoring_status` — poll until `completed`; you get the created test id.
+
+Or create directly with `create_mabl_test`, passing `name`, `testType`
+(`browser` or `api`), `applicationId`, `environmentId`, and — only if the test
+logs in — `credentialsId` from above.
+
+### Run a test in the cloud
+- One test: `run_mabl_test_cloud` with `testId`, `environmentId`,
+  `applicationId`, and a `browsers` list (at least one, e.g. `["chrome"]`) —
+  mabl resolves the matching deployment/URL automatically. Pass `urlOverride`
+  to run against an ad-hoc URL such as a preview deploy.
+- A plan: `run_mabl_plan` with the `planId` (ends in `-p`).
+```

--- a/plugins/mabl/skills/mabl-init/SKILL.md
+++ b/plugins/mabl/skills/mabl-init/SKILL.md
@@ -12,7 +12,7 @@ description: |
   Run this once per project, before authoring or running tests. For creating a
   single test use mabl-test-authoring; for a whole suite use
   mabl-test-coverage-design.
-allowed-tools: Bash, Read, Write, Edit, mcp__mabl__get_current_user, mcp__mabl__list_mabl_workspaces, mcp__mabl__list_mabl_applications, mcp__mabl__list_mabl_environments, mcp__mabl__list_mabl_credentials
+allowed-tools: Bash, Read, Write, Edit, mcp__mabl__get_current_user, mcp__mabl__list_mabl_workspaces, mcp__mabl__list_mabl_applications, mcp__mabl__list_mabl_environments, mcp__mabl__list_mabl_credentials, mcp__mabl__list_mabl_test_run_summaries
 ---
 
 # mabl init
@@ -31,6 +31,13 @@ not the mabl CLI. Start by calling `get_current_user` to grab
 ## Workflow
 
 Do these in order. Steps 1–5 gather; step 6 writes.
+
+**Write only what the user chose.** Everything you discover is shown to help
+them decide — but the memory file records only the workspace, application(s),
+environment(s), and credentials they explicitly selected or confirmed here.
+Don't add the ones they didn't pick, and don't editorialize about them (no
+"these are the other applications" asides). If you're unsure whether something
+belongs, ask — don't pad the file to look complete.
 
 ### 1. Confirm the workspace
 
@@ -77,21 +84,38 @@ and a deployment in mabl first (or that tests can still target an ad-hoc URL via
   - **(c) Ask each time** — no default; the agent asks (or the user names) the
     app/environment for each test.
 
+Whichever they pick, record the specific app + environment combos in play — the
+one default for (a), the mapped pairs for (b), or the set worth considering for
+(c). Steps 4 and 6 use exactly those combos, nothing more.
+
 ### 4. Map credentials
 
-Call `list_mabl_credentials` with the `workspaceId`. You get `id`, `name`,
-`type` (`basic` or `basic_with_totp`), and `cloud_only` — **never secrets**.
+**Don't download and dump the whole credential list.** Lead with the
+credentials actually used for the app + environment the user chose, and suggest
+only those.
 
-Show them and, for each, ask the user for a one-line **"use when…"** note
-(suggest a guess from the name, e.g. "Admin user" → "tests that need admin
-access"; let them accept, edit, or skip). If there are no credentials, note
-that auth-less tests need none.
+1. For each application + environment the user kept in step 3, call
+   `list_mabl_test_run_summaries` with the `workspaceId`, that `applicationId`,
+   and that `environmentId`. Each run row carries the `credentialsId` it really
+   used (absent when the run needed no login). Collect the credential IDs that
+   show up — those are the ones in real use for that combo.
+2. Resolve those IDs to a name and type with `list_mabl_credentials` (same
+   `workspaceId`) — use it only to look up the credentials you found, not as a
+   list to show the user wholesale.
+3. Suggest just those credentials, each with a one-line **"use when…"** note
+   (e.g. "**Standard user** (`BZDY…`) — used by live runs against **Web App /
+   Dev**"). Let the user accept, edit, or skip each, and store only the ones
+   they keep.
 
-The file stores each credential's **name, ID, and type** plus your note —
-never a username or password (the MCP server never returns those). A
-credential's *name* can embed a test-account username, and this memory file is
-meant to be committed and shared with your team — so it's fine for IDs and
-names, but never a place for real secrets.
+If a combo has no runs (or no credential on any run) and the user still wants an
+authenticated test, ask whether they'd like to pick from the workspace's
+credentials — and only then show the `list_mabl_credentials` list. If a test
+needs no login, store no credential for it.
+
+Per stored credential: **name, ID, and type** plus the note — never a username
+or password (the MCP server never returns those). A credential's *name* can
+embed a test-account username, and this file is committed and shared with your
+team, so it's fine for IDs and names but never a place for real secrets.
 
 ### 5. Pick the memory file for this client
 
@@ -116,10 +140,11 @@ Tell the user the resolved path and confirm it before writing.
   touch unrelated content.
 - **File doesn't exist** → create it with the section.
 
-Fill in the template below from what you gathered. For "Choosing an
-application & environment", keep only the one block that matches the strategy
-from step 3 — drop the other two and the `<!-- … -->` picker markers (they are
-guides for you, not content for the file).
+Fill in the template below from what you gathered, honoring the "write only what
+the user chose" rule above — no extra applications, environments, or credentials.
+For "Choosing an application & environment", keep only the one block that matches
+the strategy from step 3, and drop the other two and the `<!-- … -->` picker
+markers (guides for you, not content for the file).
 
 ### 7. Confirm and suggest a next step
 
@@ -152,6 +177,10 @@ Pass `workspaceId: <workspaceId>` on every mabl MCP call. Call
 
 ### Applications & environments
 
+<!-- Only the applications/environments the user chose in step 3 — the default
+one (a), the mapped ones (b), or the set they want considered (c). Not every
+app in the workspace. -->
+
 | Application | Application ID | Environment | Environment ID | URL |
 |-------------|----------------|-------------|----------------|-----|
 | <App name>  | `<app id>`     | <Env name>  | `<env id>`     | <url> |
@@ -160,7 +189,7 @@ Pass `workspaceId: <workspaceId>` on every mabl MCP call. Call
 
 <!-- (a) One default -->
 Default to **<App>** (`<app id>`) on **<Env>** (`<env id>`, <url>) unless I say
-otherwise. The full list is in the table above.
+otherwise.
 
 <!-- (b) Folder-based -->
 Pick the app/environment by the folder the work is in:
@@ -188,9 +217,10 @@ If a test needs no login, omit the credential.
 2. `mabl_authoring_initiate` — generate it in the cloud from that plan.
 3. `mabl_authoring_status` — poll until `completed`; you get the created test id.
 
-Or create directly with `create_mabl_test`, passing `name`, `testType`
-(`browser` or `api`), `applicationId`, `environmentId`, and — only if the test
-logs in — `credentialsId` from above.
+Or, when you already have the steps, create directly with `create_mabl_test`
+(`name`, `testType`, `applicationId`, `environmentId`, plus `credentialsId` for
+authenticated tests) and pass the steps as `initial_flow.steps` — without them
+it creates an empty, non-runnable test envelope.
 
 ### Run a test in the cloud
 - One test: `run_mabl_test_cloud` with `testId`, `environmentId`,

--- a/plugins/mabl/skills/mabl-init/SKILL.md
+++ b/plugins/mabl/skills/mabl-init/SKILL.md
@@ -70,7 +70,10 @@ something.
 If no applications or environments come back, this workspace isn't set up for
 testing yet. Don't write an empty table — tell the user to add an application
 and a deployment in mabl first (or that tests can still target an ad-hoc URL via
-`urlOverride`), and check they picked the workspace they meant in step 1.
+`urlOverride`), and check they picked the workspace they meant in step 1. Same
+if apps and environments exist but none has a deployment `url`: there's no
+deployment for `run_mabl_test_cloud` to resolve, so tell the user to add one, or
+record that runs must pass `urlOverride`.
 
 ### 3. Decide how to choose an application & environment
 
@@ -163,12 +166,13 @@ wrapper differs:
 - **Rule** → a new rule file with the client's rule frontmatter and the template
   as the body (Cursor `.mdc` with `globs`, Copilot `.instructions.md` with
   `applyTo`). For the folder-based strategy, set the globs to the mapped folders.
-- **Skill** → a `SKILL.md` (e.g. `mabl-config`) with the template as the body
-  and a **trigger-first `description`** so it actually loads when needed — it
-  must fire before any mabl work (e.g. "Read before creating or running any mabl
-  test in this project — holds the workspace, applications, and credentials to
-  use"). Without that trigger the IDs won't be in context when tests are later
-  authored, which defeats the point of saving them.
+- **Skill** → a `SKILL.md` (e.g. `mabl-config`) whose YAML frontmatter (the
+  `---` block) has a `name` and a **trigger-first `description`**, with the
+  template as the body. The description must fire before any mabl work (e.g.
+  "Read before creating or running any mabl test in this project — holds the
+  workspace, applications, and credentials to use"). Without frontmatter the
+  skill won't load; without that trigger the IDs won't be in context when tests
+  are later authored — either way it defeats the point of saving them.
 
 ### 7. Confirm and suggest a next step
 

--- a/plugins/mabl/skills/mabl-init/SKILL.md
+++ b/plugins/mabl/skills/mabl-init/SKILL.md
@@ -3,9 +3,9 @@ name: mabl-init
 description: |
   One-time project setup for mabl. Discover this user's mabl workspace,
   applications, environments, and credentials over the mabl MCP server, then
-  write everything an AI agent needs to create and run mabl cloud tests into
-  the project's agent memory file (CLAUDE.md / AGENTS.md /
-  .github/copilot-instructions.md).
+  save everything an AI agent needs to create and run mabl cloud tests where the
+  user wants it — an agent memory file (CLAUDE.md / AGENTS.md /
+  .github/copilot-instructions.md), a rule, or a skill.
   Fire when the user says "set up mabl", "mabl init", "initialize mabl",
   "configure mabl for this project", "save my mabl workspace / application /
   environment / credentials", "add mabl to my CLAUDE.md", or "/mabl-init".
@@ -19,8 +19,8 @@ allowed-tools: Bash, Read, Write, Edit, mcp__mabl__get_current_user, mcp__mabl__
 
 Prime a project so any future agent session can create and run mabl tests with
 no re-explaining. This skill reads your mabl account through the hosted `mabl`
-MCP server, asks you the handful of choices only you can make, and writes a
-`## mabl testing` section into your project's agent memory file.
+MCP server, asks you the handful of choices only you can make, and saves the
+setup where you want it — an agent memory file, a rule, or a skill.
 
 ## Prerequisites
 
@@ -117,34 +117,58 @@ or password (the MCP server never returns those). A credential's *name* can
 embed a test-account username, and this file is committed and shared with your
 team, so it's fine for IDs and names but never a place for real secrets.
 
-### 5. Pick the memory file for this client
+### 5. Choose how and where to persist the setup
 
-Determine which agent client you are running in (you know your own harness; if
-unsure, check env vars like `CLAUDECODE` or `CURSOR_*`, and look for an existing
-memory file). Map it to the right file at the project root:
+Ask the user how they want it saved — don't assume a file. Offer:
 
-| Client | File |
-|--------|------|
-| Claude Code | `./CLAUDE.md` |
-| Cursor | `./AGENTS.md` |
-| GitHub Copilot (VS Code) | `./.github/copilot-instructions.md` |
-| OpenAI Codex | `./AGENTS.md` |
-| Anything else | `./AGENTS.md` (the cross-agent default) |
+- **(a) Agent memory file** (recommended — always loaded, nothing to invoke
+  later). Then ask *where*, the way `#memory` does:
+  - **project root** — committed and shared with the team (the usual choice);
+  - **user-level** (`~/.claude/CLAUDE.md` and equivalents) — personal; applies
+    to every project you open, so only pick it if you use the same workspace
+    everywhere (the IDs are workspace-specific);
+  - **a specific path** they name (e.g. a subdirectory's memory file).
 
-Tell the user the resolved path and confirm it before writing.
+  The filename follows the client (you know your own harness; if unsure, check
+  env vars like `CLAUDECODE` / `CURSOR_*` or an existing file): Claude Code →
+  `CLAUDE.md`, Cursor / Codex → `AGENTS.md`, GitHub Copilot →
+  `.github/copilot-instructions.md`.
+- **(b) A rule** — for clients with path-scoped rules (e.g. Cursor
+  `.cursor/rules/mabl.mdc` with `globs`, GitHub Copilot
+  `.github/instructions/mabl.instructions.md` with `applyTo`). Pairs naturally
+  with the folder-based strategy from step 3 — scope the rule's globs to the
+  mapped folders so the right app/environment loads per path.
+- **(c) A skill** — a small `mabl-config` skill (a `SKILL.md` in the client's
+  skills directory, e.g. `.claude/skills/mabl-config/SKILL.md`) the agent
+  invokes on demand. Only pick this if you'd rather it not always be in context
+  — the IDs won't be loaded unless the skill is triggered.
 
-### 6. Write (or merge) the memory section
+Default to (a) at the project root. Confirm the format and the resolved path
+with the user before writing.
 
-- **File exists** → `Read` it first. If it already has a `## mabl testing`
-  section, replace just that section. Otherwise append the section. **Never**
-  touch unrelated content.
-- **File doesn't exist** → create it with the section.
+### 6. Write (or merge) the setup
 
 Fill in the template below from what you gathered, honoring the "write only what
 the user chose" rule above — no extra applications, environments, or credentials.
-For "Choosing an application & environment", keep only the one block that matches
-the strategy from step 3, and drop the other two and the `<!-- … -->` picker
-markers (guides for you, not content for the file).
+For "Choosing an application & environment", keep only the block that matches the
+strategy from step 3, and drop the other two and the `<!-- … -->` picker markers
+(guides for you, not content for the file).
+
+Then save it in the format chosen in step 5. The content is identical; only the
+wrapper differs:
+
+- **Memory file** → the template as a `## mabl testing` section. If the file
+  exists, `Read` it and replace an existing `## mabl testing` section (else
+  append) — **never** touch unrelated content. Create the file if it's missing.
+- **Rule** → a new rule file with the client's rule frontmatter and the template
+  as the body (Cursor `.mdc` with `globs`, Copilot `.instructions.md` with
+  `applyTo`). For the folder-based strategy, set the globs to the mapped folders.
+- **Skill** → a `SKILL.md` (e.g. `mabl-config`) with the template as the body
+  and a **trigger-first `description`** so it actually loads when needed — it
+  must fire before any mabl work (e.g. "Read before creating or running any mabl
+  test in this project — holds the workspace, applications, and credentials to
+  use"). Without that trigger the IDs won't be in context when tests are later
+  authored, which defeats the point of saving them.
 
 ### 7. Confirm and suggest a next step
 
@@ -156,9 +180,10 @@ and suggest a smoke check, e.g.:
 
 ---
 
-## Memory section template
+## Setup content template
 
-Write this as a `## mabl testing` section. Replace every `<…>` and drop rows /
+This is the content to save — as a `## mabl testing` section (memory file), or
+as the body of a rule or skill (see step 6). Replace every `<…>` and drop rows /
 blocks that don't apply. Reference mabl tools by their plain names (the agent
 maps them to its own MCP tool names).
 

--- a/plugins/mabl/skills/mabl-init/SKILL.md
+++ b/plugins/mabl/skills/mabl-init/SKILL.md
@@ -25,15 +25,8 @@ MCP server, asks you the handful of choices only you can make, and writes a
 ## Prerequisites
 
 This skill uses the hosted **`mabl` MCP server** (bundled with this plugin) —
-not the mabl CLI. Confirm the server is connected before doing anything else:
-
-- Call `get_current_user`.
-  - **Fails / tool unavailable** → the `mabl` MCP server isn't connected.
-    Tell the user to install and authorize it (see the plugin README —
-    `/plugin install mabl@mabl` for Claude Code, or add the
-    `https://mcp.mabl.com/mcp` server for other agents) and **stop**.
-  - **Succeeds** → remember `defaultWorkspaceId` (the fallback workspace when
-    the user doesn't pick one).
+not the mabl CLI. Start by calling `get_current_user` to grab
+`defaultWorkspaceId` (the fallback workspace when the user doesn't pick one).
 
 ## Workflow
 


### PR DESCRIPTION
New users at companies that already run mabl keep hand-writing a CLAUDE.md with a few raw IDs so their agent knows which workspace/app/environment/credentials to use — and it's always incomplete (no URLs, no "which credential when", no idea how to actually create or run a test). `mabl-init` does that setup for them, once.

It reads their mabl account through the hosted `mabl` MCP server, asks only the choices a human has to make, and saves everything a future agent session needs to author and run cloud tests. From then on the agent already knows the setup — no re-explaining.

A few behaviors worth calling out:

- **It asks how to persist the setup**, rather than assuming a file — an agent memory file (at the project root, user-level, or a path you name), a path-scoped rule (Cursor/Copilot, which pairs nicely with mapping different apps to different folders), or an on-demand skill.
- **It only writes what you actually chose** — it never dumps every app/environment/credential in the workspace into a file that gets committed and shared with the team.
- **It grounds credential suggestions in real usage** — instead of downloading the whole credential list, it looks at the runs that actually happened against the chosen app+environment and suggests the credentials those runs used. Credentials are referenced by name/ID only, never a secret.

One deliberate departure worth flagging: every existing skill opens with the mabl **CLI** install block, but this skill only uses the mabl **MCP** tools plus file writes — no CLI calls — so it skips that block and just calls `get_current_user` (provided by the bundled MCP server). Adding a CLI block it never uses felt misleading; happy to reconsider if you'd rather keep the block for consistency.

Discovery was validated live against the real hosted server, and all five plugin validators pass.