### PR TITLE
Drop the retired Runtime recovery tool from mabl-debug [1.5.1]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Official mabl plugins for AI coding agents",
-    "version": "1.5.0"
+    "version": "1.5.1"
   },
   "plugins": [
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Official mabl plugins for AI coding agents",
-    "version": "1.5.0"
+    "version": "1.5.1"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the `mabl` plugin are documented here. Format follows
 the `version` field in `plugin.json` (kept in sync across all manifests — see
 `CLAUDE.md`).
 
+## [1.5.1] - 2026-08-19
+### Removed
+- `mabl-debug` no longer points at `get_runtime_recovery_session`. Runtime
+  recovery is retired and that MCP tool no longer exists, so the skill was
+  telling agents to call something that would fail, and describing the tool's
+  output as their strongest signal for the fix. Guidance for reading an older
+  run that did recover is kept — those runs still carry the `recovered` status,
+  and a recovered step is debugged the same way as a failed one. The id table
+  also no longer claims `*-as` means Runtime recovery specifically; it is any
+  mabl agent session.
+
 ## [1.5.0] - 2026-08-19
 ### Added
 - `mabl-test-coverage-design` now plans a **copy graph** before it authors

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mabl",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
   "author": {
     "name": "mabl",

--- a/plugins/mabl/.claude-plugin/plugin.json
+++ b/plugins/mabl/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mabl",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "mabl",
     "email": "support@mabl.com",

--- a/plugins/mabl/.codex-plugin/plugin.json
+++ b/plugins/mabl/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mabl",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
   "author": {
     "name": "mabl",

--- a/plugins/mabl/.cursor-plugin/plugin.json
+++ b/plugins/mabl/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mabl",
   "displayName": "mabl",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
   "author": {
     "name": "mabl",

--- a/plugins/mabl/skills/mabl-debug/SKILL.md
+++ b/plugins/mabl/skills/mabl-debug/SKILL.md
@@ -169,24 +169,16 @@ across calls.
 ### Recovered steps
 
 A step with `status: "recovered"` is a step that **failed**, then was
-salvaged by Runtime recovery so the run could continue. The trace
-shows it as `recovered` (not passed) precisely because it's still a
-real bug — Runtime recovery papered over it for the run, but the
-underlying cause stays.
+salvaged by Runtime recovery so the run could continue. Runtime
+recovery is sunset, so no new run produces this status, but the default
+trace still surfaces it on older runs. The status is `recovered` rather
+than `passed` precisely because it marked a real bug: recovery papered
+over it for that run, but the underlying cause stayed.
 
-Each recovered entry carries `recovery.session_id` (a `*-as` id). Feed
-it to the hosted MCP's `get_runtime_recovery_session` to see what
-Runtime recovery actually did — the action it took to advance the test:
-
-```
-mcp__mabl__get_runtime_recovery_session({ session_id: "<*-as>" })
-```
-
-The recovery action is your strongest signal for the user-facing fix.
-It shows what the test needed in order to advance — which tells you
-whether the *test* is wrong (a stale selector, a missing wait, an
-assertion expecting the wrong value) or whether the *app under test*
-regressed (a precondition that used to hold no longer holds).
+Debug a recovered step the same way as a failed one: the step's own
+find/assert failure is the signal, and the fix is either the test (a
+stale selector, a missing wait, a wrong assertion) or the app (a
+regressed precondition).
 
 ---
 
@@ -205,8 +197,7 @@ For higher-level analysis the hosted **`mabl` MCP server** exposes
 `analyze_failure` (root-cause inference, related-tests, last-passing
 deploy), `get_mabl_test_details`, `get_environments`, `get_credentials`.
 Use these when the shell tools don't give enough context — same APIs,
-no shell required. For recovered steps, `get_runtime_recovery_session`
-is covered in the Triage section above.
+no shell required.
 
 ### Is this a test bug or an app bug?
 
@@ -216,7 +207,7 @@ heuristic:
 | Signal | Likely owner |
 |---|---|
 | Stack trace points into product source; failed network call to an app endpoint; new uncaught JS error after a recent deploy | **App** — `git log <last_passing_deploy>..HEAD` on the relevant repo, then file/fix in product code |
-| `status: "recovered"` with a recovery action like "click a different selector" or "wait, then retry"; stale `data-testid`; assertion expects a value the app never produced | **Test** — update the step / selector / assertion in the mabl test |
+| `status: "recovered"`; stale `data-testid`; assertion expects a value the app never produced | **Test** — update the step / selector / assertion in the mabl test |
 | Test flakes on retry but app code, DOM, and network all look healthy | **Test** — usually a missing wait or a timing assumption |
 
 When in doubt, run the live session (§3) and step through — a real
@@ -438,7 +429,7 @@ Test / run / plan ids:
 *-pr   plan run        group of test runs     abc123-pr
 *-j    test definition live-session input     abc123-j
 *-p    plan definition                        abc123-p
-*-as   agent session   Runtime recovery       abc123-as
+*-as   agent session   any mabl agent         abc123-as
 mabl-debug-<ts>        live session ID (returned by `session start`)
 ```
 


### PR DESCRIPTION
## Why

`get_runtime_recovery_session` was deleted from the mabl MCP server in mablhq/mcp#185, as part of retiring Runtime recovery. `mabl-debug` still told agents to call it, and described its output as their strongest signal for the user-facing fix, so the skill was steering agents at a tool that no longer exists.

## What this does

Removes the three references to that tool, and two related claims that depended on it:

- The **test-versus-app table** no longer cites "a recovery action like click a different selector", because that detail came from the deleted tool's response.
- The **id-suffix table** no longer says `*-as` means Runtime recovery. It is any mabl agent session.

**Guidance for older runs is kept deliberately.** Runs that did recover still carry `status: "recovered"`, and the CLI still surfaces those steps in the default trace, so an agent triaging an older failure will still meet the status and needs to know what it means. What changed is the advice: a recovered step is debugged the same way as a failed one, from its own find/assert failure, rather than by fetching a recovery session.

## What is deliberately unchanged

The documented `note` string stays `"Filtered to failed/recovered steps (N hidden). Pass --all to see the full trace."`. That is an exact string the skill instructs agents to match verbatim, and the CLI builds it by joining its default visible-status set, which still contains `recovered`. Changing it here would break agents matching a string the CLI still emits.

## Version

Bumped to `1.5.1` across the four plugin manifests and the two `marketplace.json` files that carry a version, with a `CHANGELOG.md` entry, per the repo's convention for a consumer-visible skill change. The `mabl-debug` row in `README.md` needs no edit: it describes triage and live reproduction and never mentioned recovery.

All four repo validators pass locally: Copilot manifest, template, Cursor parity, Codex parity.

## Related

mablhq/mcp#185 deleted the tool. mablhq/mabl-cli#3919 carries the equivalent scrub of the copy this repo supersedes, plus the runtime gating for the same retirement.
