### PR TITLE
Say only what a reader can act on, and add CI to keep it that way

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Official mabl plugins for AI coding agents",
-    "version": "1.6.0"
+    "version": "1.6.1"
   },
   "plugins": [
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Official mabl plugins for AI coding agents",
-    "version": "1.6.0"
+    "version": "1.6.1"
   },
   "plugins": [
     {

--- a/.github/scripts/lib/frontmatter.mjs
+++ b/.github/scripts/lib/frontmatter.mjs
@@ -64,11 +64,15 @@ export function parseFrontmatter(raw) {
           // A loader folds a continuation in with one space — except straight
           // after a paragraph break, which already supplied the newline.
           parts.push(parts.at(-1) === '\n' ? line.trim() : ` ${line.trim()}`);
-        } else if (line.trim() === '' && /^\s+\S/.test(lines[end + 1] ?? '')) {
+        } else if (line.trim() === '') {
           // A blank line inside a plain scalar is a paragraph break the loader
-          // folds to a newline, NOT the end of the value. Stopping here handed
-          // every paragraph after the first an unmeasured free ride — a 2789-
-          // character description passed this check clean.
+          // folds to a newline, NOT the end of the value. Stopping at one hands
+          // every paragraph after the first an unmeasured free ride. The run
+          // has to be scanned whole: a double-spaced break is still one scalar,
+          // so a lookahead of exactly one line ends the value just as wrongly.
+          let next = end + 1;
+          while (next < closing && lines[next].trim() === '') next++;
+          if (next >= closing || !/^\s+\S/.test(lines[next])) break;
           parts.push('\n');
         } else break;
       }

--- a/.github/scripts/lib/frontmatter.mjs
+++ b/.github/scripts/lib/frontmatter.mjs
@@ -2,10 +2,42 @@
 // rules — the part with real edge cases, and the part the description budget is
 // measured against — can be unit-tested without running the validator.
 
-// Reader for the flat `key: value` and block-scalar shape a SKILL.md uses: enough for the flat `key: value` and block-scalar
-// shape a SKILL.md uses, so this script stays dependency-free like its
-// siblings. Returns the top-level keys in source order, each key's resolved
-// string value, and the body after the closing delimiter.
+// A `#` starts a comment when it follows whitespace, so a loader drops the rest
+// of the line. Plain scalars only: inside quotes and inside a block scalar the
+// `#` is literal content.
+const stripComment = (line) => line.replace(/\s+#.*$/, '');
+
+// Fold a block scalar's lines the way its indicator says. `|` keeps every line
+// break; `>` folds a single break between two non-empty lines to a space and a
+// run of n breaks to n-1 newlines. Getting this wrong is length-neutral for one
+// break, so the budget check won't notice — but any consumer reading the text
+// gets YAML-incorrect content.
+const foldBlock = (lines, folded) => {
+  if (!folded) return lines.join('\n');
+  const out = [];
+  let blanks = 0;
+  for (const line of lines) {
+    if (line === '') { blanks += 1; continue; }
+    if (out.length) out.push(blanks === 0 ? ' ' : '\n'.repeat(blanks));
+    out.push(line);
+    blanks = 0;
+  }
+  return out.join('');
+};
+
+// Chomping decides the trailing newlines: `-` strips them, `+` keeps them all,
+// and the default — clip — keeps exactly one. Clip is what every skill uses, so
+// dropping that newline measured every block-scalar description one short.
+const chomp = (value, indicator) => {
+  if (indicator === '+') return value;
+  const stripped = value.replace(/\n+$/, '');
+  return indicator === '-' || stripped === '' ? stripped : `${stripped}\n`;
+};
+
+// Reader for the flat `key: value` and block-scalar shape a SKILL.md uses, so
+// this script stays dependency-free like its siblings. Returns the top-level
+// keys in source order, each key's resolved string value, and the body after
+// the closing delimiter.
 export function parseFrontmatter(raw) {
   // Strip the CR a CRLF checkout leaves on every line — git's default on
   // Windows, and CLAUDE.md tells contributors to run this locally. \r is a line
@@ -13,6 +45,9 @@ export function parseFrontmatter(raw) {
   // key reads as absent: a valid file reports as having no name at all.
   const lines = raw.split('\n').map((line) => (line.endsWith('\r') ? line.slice(0, -1) : line));
   if (lines[0]?.trim() !== '---') return null;
+  // A flush-left `---` ends a block scalar before it closes the document, which
+  // is what a loader does too — block content has to be indented past its key —
+  // so this blind scan agrees with YAML rather than truncating early.
   const closing = lines.findIndex((line, index) => index > 0 && /^---\s*$/.test(line));
   if (closing === -1) return null;
 
@@ -26,19 +61,17 @@ export function parseFrontmatter(raw) {
     const [, key, rest] = match;
     keys.push(key);
     const inline = rest.trim();
+    const blockHeader = /^([|>])([-+]?)\d*\s*(?:#.*)?$/.exec(inline);
 
-    if (/^[|>][-+]?\d*$/.test(inline)) {
+    if (blockHeader) {
+      const [, style, indicator] = blockHeader;
       const block = [];
       let end = i + 1;
       for (; end < closing; end++) {
         if (lines[end].trim() === '' || /^\s/.test(lines[end])) block.push(lines[end].trim());
         else break;
       }
-      // A YAML loader resolves a block scalar to ONE string — `>` folds the line
-      // breaks to spaces, `|` keeps them as newlines — so what a consumer
-      // measures is a single line either way. Measure that space-joined form;
-      // measuring the raw source lines would count the indentation too.
-      values[key] = block.join('\n').replace(/\n+$/, '');
+      values[key] = chomp(foldBlock(block, style === '>'), indicator);
       i = end - 1;
     } else if (inline === '') {
       // A nested mapping or list. Its indented lines belong to this key, so
@@ -56,14 +89,16 @@ export function parseFrontmatter(raw) {
       // measuring only the first line would silently pass a description far
       // over budget, which is the shape a contributor who doesn't know about
       // `|` writes most naturally.
-      const parts = [inline];
+      const quoted = /^(['"])([\s\S]*)\1\s*(?:#.*)?$/.exec(inline);
+      const parts = [quoted ? quoted[2] : stripComment(inline)];
       let end = i + 1;
       for (; end < closing; end++) {
         const line = lines[end];
         if (/^\s+\S/.test(line)) {
           // A loader folds a continuation in with one space — except straight
           // after a paragraph break, which already supplied the newline.
-          parts.push(parts.at(-1) === '\n' ? line.trim() : ` ${line.trim()}`);
+          const text = quoted ? line.trim() : stripComment(line.trim());
+          parts.push(parts.at(-1) === '\n' ? text : ` ${text}`);
         } else if (line.trim() === '') {
           // A blank line inside a plain scalar is a paragraph break the loader
           // folds to a newline, NOT the end of the value. Stopping at one hands
@@ -77,7 +112,11 @@ export function parseFrontmatter(raw) {
         } else break;
       }
       i = end - 1;
-      values[key] = parts.join('').replace(/^['"]|['"]$/g, '');
+      const joined = parts.join('');
+      // Strip quotes only as a matching pair. Stripping each end independently
+      // ate the closing quote off any description ending in a quoted word,
+      // which shortens the very string the 1024 budget is measured against.
+      values[key] = quoted || !/^(['"])[\s\S]*\1$/.test(joined) ? joined : joined.slice(1, -1);
     }
   }
 

--- a/.github/scripts/lib/frontmatter.mjs
+++ b/.github/scripts/lib/frontmatter.mjs
@@ -1,0 +1,82 @@
+// The frontmatter reader for validate-skills.mjs. Its own module so the folding
+// rules — the part with real edge cases, and the part the description budget is
+// measured against — can be unit-tested without running the validator.
+
+// Reader for the flat `key: value` and block-scalar shape a SKILL.md uses: enough for the flat `key: value` and block-scalar
+// shape a SKILL.md uses, so this script stays dependency-free like its
+// siblings. Returns the top-level keys in source order, each key's resolved
+// string value, and the body after the closing delimiter.
+export function parseFrontmatter(raw) {
+  // Strip the CR a CRLF checkout leaves on every line — git's default on
+  // Windows, and CLAUDE.md tells contributors to run this locally. \r is a line
+  // terminator to a JS regex, so the key pattern below stops matching and every
+  // key reads as absent: a valid file reports as having no name at all.
+  const lines = raw.split('\n').map((line) => (line.endsWith('\r') ? line.slice(0, -1) : line));
+  if (lines[0]?.trim() !== '---') return null;
+  const closing = lines.findIndex((line, index) => index > 0 && /^---\s*$/.test(line));
+  if (closing === -1) return null;
+
+  const keys = [];
+  const values = {};
+  for (let i = 1; i < closing; i++) {
+    // Continuation lines of a block scalar are indented, so they never match
+    // this anchored pattern — the block-scalar branch below consumes them.
+    const match = /^([A-Za-z0-9_-]+):(.*)$/.exec(lines[i]);
+    if (!match) continue;
+    const [, key, rest] = match;
+    keys.push(key);
+    const inline = rest.trim();
+
+    if (/^[|>][-+]?\d*$/.test(inline)) {
+      const block = [];
+      let end = i + 1;
+      for (; end < closing; end++) {
+        if (lines[end].trim() === '' || /^\s/.test(lines[end])) block.push(lines[end].trim());
+        else break;
+      }
+      // A YAML loader resolves a block scalar to ONE string — `>` folds the line
+      // breaks to spaces, `|` keeps them as newlines — so what a consumer
+      // measures is a single line either way. Measure that space-joined form;
+      // measuring the raw source lines would count the indentation too.
+      values[key] = block.join('\n').replace(/\n+$/, '');
+      i = end - 1;
+    } else if (inline === '') {
+      // A nested mapping or list. Its indented lines belong to this key, so
+      // consume them — none of the checked keys use that shape.
+      values[key] = '';
+      let end = i + 1;
+      for (; end < closing; end++) {
+        if (lines[end].trim() === '' || /^\s/.test(lines[end])) continue;
+        break;
+      }
+      i = end - 1;
+    } else {
+      // A plain or quoted scalar can continue onto indented lines, which a YAML
+      // loader folds into the value with single spaces. Fold them the same way —
+      // measuring only the first line would silently pass a description far
+      // over budget, which is the shape a contributor who doesn't know about
+      // `|` writes most naturally.
+      const parts = [inline];
+      let end = i + 1;
+      for (; end < closing; end++) {
+        const line = lines[end];
+        if (/^\s+\S/.test(line)) {
+          // A loader folds a continuation in with one space — except straight
+          // after a paragraph break, which already supplied the newline.
+          parts.push(parts.at(-1) === '\n' ? line.trim() : ` ${line.trim()}`);
+        } else if (line.trim() === '' && /^\s+\S/.test(lines[end + 1] ?? '')) {
+          // A blank line inside a plain scalar is a paragraph break the loader
+          // folds to a newline, NOT the end of the value. Stopping here handed
+          // every paragraph after the first an unmeasured free ride — a 2789-
+          // character description passed this check clean.
+          parts.push('\n');
+        } else break;
+      }
+      i = end - 1;
+      values[key] = parts.join('').replace(/^['"]|['"]$/g, '');
+    }
+  }
+
+  const body = lines.slice(closing + 1).join('\n');
+  return { keys, values, body };
+}

--- a/.github/scripts/lib/frontmatter.test.mjs
+++ b/.github/scripts/lib/frontmatter.test.mjs
@@ -24,6 +24,15 @@ test('a blank line inside a plain scalar is a fold point, not the end of the val
   assert.ok(values.description.length > 'para one'.length);
 });
 
+test('a RUN of blank lines inside a plain scalar is still one value', () => {
+  // A lookahead of exactly one line ends the value at a double-spaced
+  // paragraph break, which reported a 2730-character description as being
+  // within 1024 characters.
+  const { values } = parseFrontmatter(wrap('name: a\ndescription: para one\n\n\n  para two'));
+  assert.match(values.description, /para two/, 'text after a double blank must be measured');
+  assert.equal(values.description, 'para one\n\npara two');
+});
+
 test('a `|` block resolves to one string and does not count source indentation', () => {
   const { values } = parseFrontmatter(wrap('name: a\ndescription: |\n  line one\n  line two'));
   assert.equal(values.description, 'line one\nline two');
@@ -69,8 +78,32 @@ test('a colon inside a block scalar is not read as a new key', () => {
   assert.deepEqual(keys, ['name', 'description']);
 });
 
+test('a colon inside a one-line plain scalar is not read as a new key', () => {
+  // The block-scalar case above never reaches the key pattern — the block branch
+  // consumes those lines. This is the shape that does reach it, and the shape a
+  // description is most often written in, so it is what pins the anchor.
+  const { keys, values } = parseFrontmatter(wrap('name: a\ndescription: use this when: the user asks'));
+  assert.deepEqual(keys, ['name', 'description']);
+  assert.equal(values.description, 'use this when: the user asks');
+});
+
+test('a key AFTER a block scalar is still reported', () => {
+  // The only survivor of this suite that failed OPEN: consuming one line too
+  // many swallows the following key, and check 3 reads `keys` to reject the
+  // Claude-only frontmatter that breaks claude.ai upload. A swallowed `model`
+  // is a skill that validates green and then fails on the surface.
+  const { keys, values } = parseFrontmatter(wrap('name: a\ndescription: |\n  a block\n  of text\nmodel: opus'));
+  assert.deepEqual(keys, ['name', 'description', 'model']);
+  assert.equal(values.model, 'opus');
+});
+
 test('no opening delimiter resolves to null', () => {
   assert.equal(parseFrontmatter('name: a\ndescription: b\n'), null);
+  // With no `---` anywhere, the closing search returns null on its own and the
+  // opening check is never what answers. A `---` further down — a horizontal
+  // rule in a file that simply has no frontmatter — is what actually exercises
+  // it, and must not be read as the close of a block that never opened.
+  assert.equal(parseFrontmatter('intro prose\nname: sneaky\n---\nafter\n'), null);
 });
 
 test('an unclosed frontmatter block resolves to null', () => {

--- a/.github/scripts/lib/frontmatter.test.mjs
+++ b/.github/scripts/lib/frontmatter.test.mjs
@@ -33,21 +33,74 @@ test('a RUN of blank lines inside a plain scalar is still one value', () => {
   assert.equal(values.description, 'para one\n\npara two');
 });
 
-test('a `|` block resolves to one string and does not count source indentation', () => {
+test('a `|` block keeps its line breaks and does not count source indentation', () => {
   const { values } = parseFrontmatter(wrap('name: a\ndescription: |\n  line one\n  line two'));
-  assert.equal(values.description, 'line one\nline two');
+  assert.equal(values.description, 'line one\nline two\n');
 });
 
-test('a `>` block folds to a single measurable string', () => {
+test('a `>` block folds line breaks to SPACES, unlike `|`', () => {
+  // The parser joined with \n for both indicators while its own comment claimed
+  // otherwise. Length-neutral for a single break, so the budget check never
+  // caught it — and the old test asserted the wrong string as correct.
   const { values } = parseFrontmatter(wrap('name: a\ndescription: >\n  line one\n  line two'));
-  assert.equal(values.description, 'line one\nline two');
+  assert.equal(values.description, 'line one line two\n');
+});
+
+test('a `>` block turns a blank line into a newline, not a space', () => {
+  const { values } = parseFrontmatter(wrap('name: a\ndescription: >\n  one\n\n  two'));
+  assert.equal(values.description, 'one\ntwo\n');
 });
 
 test('a block scalar spends budget on its blank lines', () => {
   // filter(Boolean) used to drop these, undercounting a multi-paragraph
   // description by one character per break.
   const { values } = parseFrontmatter(wrap('name: a\ndescription: |\n  one\n\n  two'));
-  assert.equal(values.description, 'one\n\ntwo');
+  assert.equal(values.description, 'one\n\ntwo\n');
+});
+
+test('clip chomping keeps exactly one trailing newline', () => {
+  // The default for `|` and `>`. Stripping it measured every block-scalar
+  // description one character short of what a loader resolves.
+  assert.equal(parseFrontmatter(wrap('name: a\ndescription: |\n  one\n')).values.description, 'one\n');
+});
+
+test('the `-` and `+` chomping indicators override clip', () => {
+  assert.equal(parseFrontmatter(wrap('name: a\ndescription: |-\n  one')).values.description, 'one');
+  assert.equal(parseFrontmatter(wrap('name: a\ndescription: |+\n  one\n\n')).values.description, 'one\n\n');
+});
+
+test('quotes are stripped only as a matching pair', () => {
+  // Stripping each end independently ate the closing quote off any description
+  // ending in a quoted word — shortening the string the budget is measured on.
+  const { values } = parseFrontmatter(wrap('name: a\ndescription: fire when the user says "hello"'));
+  assert.equal(values.description, 'fire when the user says "hello"');
+  assert.equal(parseFrontmatter(wrap("name: a\ndescription: it belongs to the users'")).values.description,
+    "it belongs to the users'");
+});
+
+test('an inline # comment is not part of the value', () => {
+  // check 1 compares `name` to the folder byte-for-byte, so a contributor
+  // writing an ordinary YAML comment used to fail CI on valid YAML.
+  assert.equal(parseFrontmatter(wrap('name: mabl-debug  # a comment')).values.name, 'mabl-debug');
+  assert.equal(parseFrontmatter(wrap('name: a\ndescription: fix issue #123')).values.description, 'fix issue');
+});
+
+test('a # inside quotes or a block scalar stays literal', () => {
+  assert.equal(parseFrontmatter(wrap('name: a\ndescription: "keeps # this"')).values.description, 'keeps # this');
+  assert.equal(parseFrontmatter(wrap('name: a\ndescription: |\n  a # literal hash')).values.description,
+    'a # literal hash\n');
+});
+
+test('a comment after a closing quote is dropped', () => {
+  assert.equal(parseFrontmatter(wrap('name: a\ndescription: "quoted"  # real comment')).values.description,
+    'quoted');
+});
+
+test('a flush-left --- ends the block scalar, matching a real loader', () => {
+  // Not a truncation bug: block content must be indented past its key, so a
+  // pasted flush-left horizontal rule is outside the scalar for PyYAML too.
+  const { values } = parseFrontmatter('---\nname: a\ndescription: |\n  intro\n---\n  more\n---\nbody\n');
+  assert.equal(values.description, 'intro\n');
 });
 
 test('a quoted scalar loses its quotes', () => {

--- a/.github/scripts/lib/frontmatter.test.mjs
+++ b/.github/scripts/lib/frontmatter.test.mjs
@@ -1,0 +1,83 @@
+// The description budget is measured against whatever parseFrontmatter resolves,
+// so its folding rules decide whether that check holds. It has failed open twice
+// — once measuring only the first line of a plain scalar, once stopping at a
+// blank line inside one — and both times the failure was a silent PASS. Each
+// case below pins one resolution rule, so the next shape it can't see fails
+// loudly here instead of quietly in CI.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseFrontmatter } from './frontmatter.mjs';
+
+const wrap = (frontmatter) => `---\n${frontmatter}\n---\nbody text\n`;
+
+test('a plain scalar continuing onto indented lines folds with single spaces', () => {
+  const { values } = parseFrontmatter(wrap('name: a\ndescription: one\n  two\n  three'));
+  assert.equal(values.description, 'one two three');
+});
+
+test('a blank line inside a plain scalar is a fold point, not the end of the value', () => {
+  // The regression: stopping here measured the first paragraph and let a
+  // 2789-character description pass the budget check clean.
+  const { values } = parseFrontmatter(wrap('name: a\ndescription: para one\n\n  para two\n  still two'));
+  assert.match(values.description, /para one/);
+  assert.match(values.description, /para two/, 'second paragraph must be measured');
+  assert.ok(values.description.length > 'para one'.length);
+});
+
+test('a `|` block resolves to one string and does not count source indentation', () => {
+  const { values } = parseFrontmatter(wrap('name: a\ndescription: |\n  line one\n  line two'));
+  assert.equal(values.description, 'line one\nline two');
+});
+
+test('a `>` block folds to a single measurable string', () => {
+  const { values } = parseFrontmatter(wrap('name: a\ndescription: >\n  line one\n  line two'));
+  assert.equal(values.description, 'line one\nline two');
+});
+
+test('a block scalar spends budget on its blank lines', () => {
+  // filter(Boolean) used to drop these, undercounting a multi-paragraph
+  // description by one character per break.
+  const { values } = parseFrontmatter(wrap('name: a\ndescription: |\n  one\n\n  two'));
+  assert.equal(values.description, 'one\n\ntwo');
+});
+
+test('a quoted scalar loses its quotes', () => {
+  const { values } = parseFrontmatter(wrap('name: a\ndescription: "quoted value"'));
+  assert.equal(values.description, 'quoted value');
+});
+
+test('CRLF line endings still resolve every key', () => {
+  // git's default on Windows. \r is a line terminator to a JS regex, so this
+  // used to report a valid file as having no frontmatter at all.
+  const raw = '---\r\nname: mabl-init\r\ndescription: set up mabl\r\n---\r\nbody\r\n';
+  const parsed = parseFrontmatter(raw);
+  assert.notEqual(parsed, null, 'CRLF frontmatter must parse');
+  assert.equal(parsed.values.name, 'mabl-init');
+  assert.equal(parsed.values.description, 'set up mabl');
+});
+
+test('a nested mapping is recorded as a key without swallowing the key after it', () => {
+  const { keys, values } = parseFrontmatter(
+    wrap('name: a\nmetadata:\n  nested: value\ndescription: after the mapping'),
+  );
+  assert.ok(keys.includes('metadata'), 'the nested key is still reported for the spec-key check');
+  assert.equal(values.description, 'after the mapping');
+});
+
+test('a colon inside a block scalar is not read as a new key', () => {
+  const { keys } = parseFrontmatter(wrap('name: a\ndescription: |\n  fire when: the user asks'));
+  assert.deepEqual(keys, ['name', 'description']);
+});
+
+test('no opening delimiter resolves to null', () => {
+  assert.equal(parseFrontmatter('name: a\ndescription: b\n'), null);
+});
+
+test('an unclosed frontmatter block resolves to null', () => {
+  assert.equal(parseFrontmatter('---\nname: a\ndescription: b\n'), null);
+});
+
+test('the body starts after the closing delimiter', () => {
+  const { body } = parseFrontmatter(wrap('name: a\ndescription: b'));
+  assert.match(body, /^body text/);
+});

--- a/.github/scripts/validate-skills.mjs
+++ b/.github/scripts/validate-skills.mjs
@@ -31,6 +31,23 @@ const DESCRIPTION_LIMIT = 1024;
 // Cursor.
 const SPEC_KEYS = ['name', 'description', 'license', 'compatibility', 'metadata', 'allowed-tools'];
 
+// The phrase a routing hand-off uses to make the reader check the sibling is
+// there. A fixed marker keeps check 4 greppable without asking CI to understand
+// prose.
+const AVAILABILITY_MARKER = 'in your available skills';
+
+// Every .md under a skill folder, recursively, so a route stated in references/
+// is checked too.
+function markdownFilesIn(dir) {
+  const found = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) found.push(...markdownFilesIn(full));
+    else if (entry.name.endsWith('.md')) found.push(full);
+  }
+  return found;
+}
+
 // Minimal frontmatter reader: enough for the flat `key: value` and block-scalar
 // shape a SKILL.md uses, so this script stays dependency-free like its
 // siblings. Returns the top-level keys in source order, each key's resolved
@@ -124,6 +141,15 @@ for (const folder of skillNames) {
   }
   const { keys, values, body } = frontmatter;
 
+  // SKILL.md contributes its body only (the description is exempt — see check
+  // 4); every other markdown file in the folder contributes its whole text.
+  const routableFiles = [[rel, body]];
+  for (const file of markdownFilesIn(join(skillsRoot, folder))) {
+    if (file === path) continue;
+    const relFile = `plugins/mabl/skills/${folder}/${file.slice(join(skillsRoot, folder).length + 1)}`;
+    routableFiles.push([relFile, readFileSync(file, 'utf8')]);
+  }
+
   // 1. Folder name equality. CLAUDE.md: a mismatched or prefixed name silently
   // fails to load in Copilot, so this can't be left to review.
   if (!values.name) {
@@ -156,23 +182,29 @@ for (const folder of skillNames) {
     }
   }
 
-  // 4. Every sibling skill the body routes to must come with an availability
-  // check. A skill can be installed on its own — `gh skill install` copies one
-  // folder, and the five surfaces install differently — so a pointer to a
-  // sibling dangles silently for anyone who has only this one. The skill must
-  // notice and say which skill is missing; it must NOT name an install
-  // mechanism, because it can't know which of the five surfaces the reader
-  // used. Match the mention in the body (the frontmatter description routes for
-  // the matcher, and has a 1024-char budget to keep) and accept the marker
-  // anywhere in the file.
-  const AVAILABILITY_MARKER = 'in your available skills';
-  for (const sibling of skillNames) {
-    if (sibling === folder) continue;
-    const mention = new RegExp(`(?<![a-z0-9-])${sibling}(?![a-z0-9-])`);
-    if (mention.test(body) && !body.includes(AVAILABILITY_MARKER)) {
-      errors.push(
-        `${rel}: the body names the sibling skill "${sibling}" but never has the reader confirm it is available — a skill can be installed on its own, so that pointer dangles for anyone who has only "${folder}"; add a check saying to confirm "${sibling}" is "${AVAILABILITY_MARKER}" and to name it if it is missing, or reword the mention so nothing routes there`,
-      );
+  // 4. Every sibling skill a file routes to must come with an availability
+  // check in THAT SAME FILE. A skill can be installed on its own, so a pointer
+  // to a sibling dangles silently for anyone who has only this one. The check
+  // must name the missing skill and must NOT name an install mechanism — the
+  // skill cannot know which of the five surfaces the reader installed from.
+  //
+  // Scoped per file, not per folder: a references/ file is loaded on its own, so
+  // an agent acting from one may not have SKILL.md in context. A route stated
+  // there with the check back in SKILL.md is a check the reader never sees.
+  // Routing belongs in SKILL.md anyway — a references/ file that trips this
+  // usually wants rewording rather than a second copy of the check.
+  //
+  // The frontmatter description is exempt: it routes for the matcher and has a
+  // 1024-character budget to keep.
+  for (const [file, text] of routableFiles) {
+    for (const sibling of skillNames) {
+      if (sibling === folder) continue;
+      const mention = new RegExp(`(?<![a-z0-9-])${sibling}(?![a-z0-9-])`);
+      if (mention.test(text) && !text.includes(AVAILABILITY_MARKER)) {
+        errors.push(
+          `${file}: names the sibling skill "${sibling}" but never has the reader confirm it is available — a skill can be installed on its own, so that pointer dangles for anyone who has only "${folder}"; add a check in this file saying to confirm "${sibling}" is "${AVAILABILITY_MARKER}" and to name it if it is missing, or reword the mention so nothing routes there (routing belongs in SKILL.md)`,
+        );
+      }
     }
   }
 }

--- a/.github/scripts/validate-skills.mjs
+++ b/.github/scripts/validate-skills.mjs
@@ -15,6 +15,7 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parseFrontmatter } from './lib/frontmatter.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const skillsRoot = join(repoRoot, 'plugins', 'mabl', 'skills');
@@ -38,81 +39,32 @@ const SPEC_KEYS = ['name', 'description', 'license', 'compatibility', 'metadata'
 // fallback beside it is correct — that stays a review item.
 const requiresDeclaration = (sibling) => `**Requires \`${sibling}\`.**`;
 
+// A skill name — folder or frontmatter — is lowercase letters, numbers, hyphens.
+const SKILL_NAME = /^[a-z0-9-]+$/;
+
+// A folder name reaches `new RegExp` below, and on a public repo anyone can open
+// a PR that adds a folder. An unbalanced bracket throws a raw SyntaxError before
+// any collected error prints; `(a+)+$` backtracks forever against any .md body,
+// which with no job timeout is a free six-hour runner. Gate, then escape.
+const escapeForRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 // Every .md under a skill folder, recursively, so a route stated in references/
 // is checked too.
 function markdownFilesIn(dir) {
   const found = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    // Vendored and tooling trees are not ours to lint: a skill folder may ship
+    // scripts with their own dependencies, and a third-party README naming a
+    // mabl skill is not a hand-off anyone here can fix.
+    if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
     const full = join(dir, entry.name);
+    // Never follow a symlink. `gh skill install` copies the folder, so a link
+    // out of it arrives broken on the reader's machine anyway.
+    if (entry.isSymbolicLink()) continue;
     if (entry.isDirectory()) found.push(...markdownFilesIn(full));
-    else if (entry.name.endsWith('.md')) found.push(full);
+    else if (entry.isFile() && entry.name.endsWith('.md')) found.push(full);
   }
   return found;
-}
-
-// Minimal frontmatter reader: enough for the flat `key: value` and block-scalar
-// shape a SKILL.md uses, so this script stays dependency-free like its
-// siblings. Returns the top-level keys in source order, each key's resolved
-// string value, and the body after the closing delimiter.
-function parseFrontmatter(raw) {
-  const lines = raw.split('\n');
-  if (lines[0]?.trim() !== '---') return null;
-  const closing = lines.indexOf('---', 1);
-  if (closing === -1) return null;
-
-  const keys = [];
-  const values = {};
-  for (let i = 1; i < closing; i++) {
-    // Continuation lines of a block scalar are indented, so they never match
-    // this anchored pattern — the block-scalar branch below consumes them.
-    const match = /^([A-Za-z0-9_-]+):(.*)$/.exec(lines[i]);
-    if (!match) continue;
-    const [, key, rest] = match;
-    keys.push(key);
-    const inline = rest.trim();
-
-    if (/^[|>][-+]?\d*$/.test(inline)) {
-      const block = [];
-      let end = i + 1;
-      for (; end < closing; end++) {
-        if (lines[end].trim() === '' || /^\s/.test(lines[end])) block.push(lines[end].trim());
-        else break;
-      }
-      // A YAML loader resolves a block scalar to ONE string — `>` folds the line
-      // breaks to spaces, `|` keeps them as newlines — so what a consumer
-      // measures is a single line either way. Measure that space-joined form;
-      // measuring the raw source lines would count the indentation too.
-      values[key] = block.filter(Boolean).join(' ');
-      i = end - 1;
-    } else if (inline === '') {
-      // A nested mapping or list. Its indented lines belong to this key, so
-      // consume them — none of the checked keys use that shape.
-      values[key] = '';
-      let end = i + 1;
-      for (; end < closing; end++) {
-        if (lines[end].trim() === '' || /^\s/.test(lines[end])) continue;
-        break;
-      }
-      i = end - 1;
-    } else {
-      // A plain or quoted scalar can continue onto indented lines, which a YAML
-      // loader folds into the value with single spaces. Fold them the same way —
-      // measuring only the first line would silently pass a description far
-      // over budget, which is the shape a contributor who doesn't know about
-      // `|` writes most naturally.
-      const parts = [inline];
-      let end = i + 1;
-      for (; end < closing; end++) {
-        if (/^\s+\S/.test(lines[end])) parts.push(lines[end].trim());
-        else break;
-      }
-      i = end - 1;
-      values[key] = parts.join(' ').replace(/^['"]|['"]$/g, '');
-    }
-  }
-
-  const body = lines.slice(closing + 1).join('\n');
-  return { keys, values, body };
 }
 
 // Report a missing skills root the way the sibling validators report a missing
@@ -125,9 +77,26 @@ const skillNames = existsSync(skillsRoot)
   : [];
 if (!existsSync(skillsRoot)) {
   errors.push('plugins/mabl/skills/ is missing — the plugin has no skills to validate');
+} else if (skillNames.length === 0) {
+  // Otherwise a wiped-out skills directory reports "All 0 skills are valid".
+  errors.push('plugins/mabl/skills/ has no skill folders — the plugin ships no skills');
 }
 
-for (const folder of skillNames) {
+// Report a folder name that can't be a skill name, and drop it before it is
+// used as one. Check 1 constrains the FRONTMATTER name; the FOLDER name is what
+// reaches the pattern below.
+const validSkillNames = skillNames.filter((folder) => {
+  if (SKILL_NAME.test(folder)) return true;
+  errors.push(`plugins/mabl/skills/${folder}/: folder name must be lowercase letters, numbers and hyphens only`);
+  return false;
+});
+
+// One pattern per sibling, compiled once from a name already proven clean.
+const mentionPatterns = new Map(
+  validSkillNames.map((name) => [name, new RegExp(`(?<![a-z0-9-])${escapeForRegExp(name)}(?![a-z0-9-])`)]),
+);
+
+for (const folder of validSkillNames) {
   const rel = `plugins/mabl/skills/${folder}/SKILL.md`;
   const path = join(skillsRoot, folder, 'SKILL.md');
   if (!existsSync(path)) {
@@ -199,9 +168,8 @@ for (const folder of skillNames) {
   // The frontmatter description is exempt: it routes for the matcher and has a
   // 1024-character budget to keep.
   for (const [file, text] of routableFiles) {
-    for (const sibling of skillNames) {
+    for (const [sibling, mention] of mentionPatterns) {
       if (sibling === folder) continue;
-      const mention = new RegExp(`(?<![a-z0-9-])${sibling}(?![a-z0-9-])`);
       if (mention.test(text) && !text.includes(requiresDeclaration(sibling))) {
         errors.push(
           `${file}: names the sibling skill "${sibling}" but never declares it as a dependency — a skill can be installed on its own, so that pointer dangles for anyone who has only "${folder}"; add "${requiresDeclaration(sibling)}" in this file at the hand-off, followed by what to do when the skill isn't there, or reword the mention so nothing routes there (routing belongs in SKILL.md)`,
@@ -218,5 +186,5 @@ if (errors.length) {
 }
 
 console.log(
-  `All ${skillNames.length} skills in plugins/mabl/skills/ are valid: name matches folder, description within ${DESCRIPTION_LIMIT} characters, spec-only frontmatter keys, and a declared dependency for every sibling it routes to.`,
+  `All ${validSkillNames.length} skills in plugins/mabl/skills/ are valid: name matches folder, description within ${DESCRIPTION_LIMIT} characters, spec-only frontmatter keys, and a declared dependency for every sibling it routes to.`,
 );

--- a/.github/scripts/validate-skills.mjs
+++ b/.github/scripts/validate-skills.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// Validates the skills in plugins/mabl/skills/ against the constraints the
+// install surfaces impose but no official validator checks:
+//   1. Frontmatter `name` equals the folder name — a mismatched or prefixed
+//      name silently fails to load in Copilot (see CLAUDE.md).
+//   2. The resolved `description` fits in 1024 characters — OpenAI Codex hard-
+//      truncates there, mid-word, so anything past it never reaches the matcher
+//      that decides whether the skill fires.
+//   3. Only the six frontmatter keys the Agent Skills spec allows.
+//   4. A body that routes to a sibling skill first has the reader confirm that
+//      skill is available — a skill can be installed on its own, and the skill
+//      cannot know which of the five surfaces installed it, so it names the
+//      missing skill rather than an install command.
+// Exits non-zero with a clear message on any failure.
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const skillsRoot = join(repoRoot, 'plugins', 'mabl', 'skills');
+const errors = [];
+
+// Codex truncates a skill description at this many characters.
+const DESCRIPTION_LIMIT = 1024;
+
+// The complete key list from the Agent Skills spec. Claude Code-only fields
+// (`disable-model-invocation`, `user-invocable`, `model`, `context`, `hooks`)
+// are deliberately NOT here: they make claude.ai skill upload, the Skills API,
+// and package_skill.py fail with a hard "Unexpected key(s)" error, and a
+// plugin-delivered skill carrying `disable-model-invocation` is invisible in
+// Cursor.
+const SPEC_KEYS = ['name', 'description', 'license', 'compatibility', 'metadata', 'allowed-tools'];
+
+// Minimal frontmatter reader: enough for the flat `key: value` and block-scalar
+// shape a SKILL.md uses, so this script stays dependency-free like its
+// siblings. Returns the top-level keys in source order, each key's resolved
+// string value, and the body after the closing delimiter.
+function parseFrontmatter(raw) {
+  const lines = raw.split('\n');
+  if (lines[0]?.trim() !== '---') return null;
+  const closing = lines.indexOf('---', 1);
+  if (closing === -1) return null;
+
+  const keys = [];
+  const values = {};
+  for (let i = 1; i < closing; i++) {
+    // Continuation lines of a block scalar are indented, so they never match
+    // this anchored pattern — the block-scalar branch below consumes them.
+    const match = /^([A-Za-z0-9_-]+):(.*)$/.exec(lines[i]);
+    if (!match) continue;
+    const [, key, rest] = match;
+    keys.push(key);
+    const inline = rest.trim();
+
+    if (/^[|>][-+]?\d*$/.test(inline)) {
+      const block = [];
+      let end = i + 1;
+      for (; end < closing; end++) {
+        if (lines[end].trim() === '' || /^\s/.test(lines[end])) block.push(lines[end].trim());
+        else break;
+      }
+      // A YAML loader resolves a block scalar to ONE string — `>` folds the line
+      // breaks to spaces, `|` keeps them as newlines — so what a consumer
+      // measures is a single line either way. Measure that space-joined form;
+      // measuring the raw source lines would count the indentation too.
+      values[key] = block.filter(Boolean).join(' ');
+      i = end - 1;
+    } else if (inline === '') {
+      // A nested mapping or list. Its indented lines belong to this key, so
+      // consume them — none of the checked keys use that shape.
+      values[key] = '';
+      let end = i + 1;
+      for (; end < closing; end++) {
+        if (lines[end].trim() === '' || /^\s/.test(lines[end])) continue;
+        break;
+      }
+      i = end - 1;
+    } else {
+      // A plain or quoted scalar can continue onto indented lines, which a YAML
+      // loader folds into the value with single spaces. Fold them the same way —
+      // measuring only the first line would silently pass a description far
+      // over budget, which is the shape a contributor who doesn't know about
+      // `|` writes most naturally.
+      const parts = [inline];
+      let end = i + 1;
+      for (; end < closing; end++) {
+        if (/^\s+\S/.test(lines[end])) parts.push(lines[end].trim());
+        else break;
+      }
+      i = end - 1;
+      values[key] = parts.join(' ').replace(/^['"]|['"]$/g, '');
+    }
+  }
+
+  const body = lines.slice(closing + 1).join('\n');
+  return { keys, values, body };
+}
+
+// Report a missing skills root the way the sibling validators report a missing
+// file, rather than letting readdirSync throw a raw ENOENT stack trace.
+const skillNames = existsSync(skillsRoot)
+  ? readdirSync(skillsRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort()
+  : [];
+if (!existsSync(skillsRoot)) {
+  errors.push('plugins/mabl/skills/ is missing — the plugin has no skills to validate');
+}
+
+for (const folder of skillNames) {
+  const rel = `plugins/mabl/skills/${folder}/SKILL.md`;
+  const path = join(skillsRoot, folder, 'SKILL.md');
+  if (!existsSync(path)) {
+    errors.push(`${rel} is missing — every skill folder needs a SKILL.md`);
+    continue;
+  }
+
+  const raw = readFileSync(path, 'utf8');
+  const frontmatter = parseFrontmatter(raw);
+  if (!frontmatter) {
+    errors.push(`${rel}: no YAML frontmatter — the file must open with a "---" delimited block`);
+    continue;
+  }
+  const { keys, values, body } = frontmatter;
+
+  // 1. Folder name equality. CLAUDE.md: a mismatched or prefixed name silently
+  // fails to load in Copilot, so this can't be left to review.
+  if (!values.name) {
+    errors.push(`${rel}: "name" is required`);
+  } else if (!/^[a-z0-9-]+$/.test(values.name)) {
+    errors.push(
+      `${rel}: "name" must be lowercase letters, numbers and hyphens only, got "${values.name}" — a path or colon prefix ("mabl/debug", "mabl:debug") silently fails to load in Copilot`,
+    );
+  } else if (values.name !== folder) {
+    errors.push(
+      `${rel}: "name" is "${values.name}" but the folder is "${folder}" — they must match byte-for-byte or the skill silently fails to load in Copilot`,
+    );
+  }
+
+  // 2. Description budget.
+  if (!values.description) {
+    errors.push(`${rel}: "description" is required`);
+  } else if (values.description.length > DESCRIPTION_LIMIT) {
+    errors.push(
+      `${rel}: "description" resolves to ${values.description.length} characters, over the ${DESCRIPTION_LIMIT}-character budget — OpenAI Codex hard-truncates a skill description at ${DESCRIPTION_LIMIT} characters mid-word, so everything past that never reaches the matcher that decides whether the skill fires`,
+    );
+  }
+
+  // 3. Spec-only frontmatter keys.
+  for (const key of keys) {
+    if (!SPEC_KEYS.includes(key)) {
+      errors.push(
+        `${rel}: unexpected frontmatter key "${key}" — the Agent Skills spec allows only ${SPEC_KEYS.join(', ')}, and anything else fails claude.ai skill upload, the Skills API, and package_skill.py with a hard "Unexpected key(s)" error`,
+      );
+    }
+  }
+
+  // 4. Every sibling skill the body routes to must come with an availability
+  // check. A skill can be installed on its own — `gh skill install` copies one
+  // folder, and the five surfaces install differently — so a pointer to a
+  // sibling dangles silently for anyone who has only this one. The skill must
+  // notice and say which skill is missing; it must NOT name an install
+  // mechanism, because it can't know which of the five surfaces the reader
+  // used. Match the mention in the body (the frontmatter description routes for
+  // the matcher, and has a 1024-char budget to keep) and accept the marker
+  // anywhere in the file.
+  const AVAILABILITY_MARKER = 'in your available skills';
+  for (const sibling of skillNames) {
+    if (sibling === folder) continue;
+    const mention = new RegExp(`(?<![a-z0-9-])${sibling}(?![a-z0-9-])`);
+    if (mention.test(body) && !body.includes(AVAILABILITY_MARKER)) {
+      errors.push(
+        `${rel}: the body names the sibling skill "${sibling}" but never has the reader confirm it is available — a skill can be installed on its own, so that pointer dangles for anyone who has only "${folder}"; add a check saying to confirm "${sibling}" is "${AVAILABILITY_MARKER}" and to name it if it is missing, or reword the mention so nothing routes there`,
+      );
+    }
+  }
+}
+
+if (errors.length) {
+  console.error('Skill validation failed:');
+  for (const error of errors) console.error(`  - ${error}`);
+  process.exit(1);
+}
+
+console.log(
+  `All ${skillNames.length} skills in plugins/mabl/skills/ are valid: name matches folder, description within ${DESCRIPTION_LIMIT} characters, spec-only frontmatter keys, and an availability check for every sibling it routes to.`,
+);

--- a/.github/scripts/validate-skills.mjs
+++ b/.github/scripts/validate-skills.mjs
@@ -94,9 +94,13 @@ const validSkillNames = skillNames.filter((folder) => {
   return false;
 });
 
-// One pattern per sibling, compiled once from a name already proven clean.
+// One pattern per sibling, compiled once from a name already proven clean. `/`
+// is excluded on both sides so a path — `plugins/mabl/skills/mabl-test-edit/`,
+// `references/mabl-test-edit.md` — isn't read as a routing hand-off and doesn't
+// demand a declaration for a link that routes nobody anywhere. A trailing `.`
+// stays a boundary, because "use mabl-test-edit." is a real mention.
 const mentionPatterns = new Map(
-  validSkillNames.map((name) => [name, new RegExp(`(?<![a-z0-9-])${escapeForRegExp(name)}(?![a-z0-9-])`)]),
+  validSkillNames.map((name) => [name, new RegExp(`(?<![a-z0-9-/])${escapeForRegExp(name)}(?![a-z0-9-/])`)]),
 );
 
 for (const folder of validSkillNames) {
@@ -139,7 +143,7 @@ for (const folder of validSkillNames) {
   // fails to load in Copilot, so this can't be left to review.
   if (!values.name) {
     errors.push(`${rel}: "name" is required`);
-  } else if (!/^[a-z0-9-]+$/.test(values.name)) {
+  } else if (!SKILL_NAME.test(values.name)) {
     errors.push(
       `${rel}: "name" must be lowercase letters, numbers and hyphens only, got "${values.name}" — a path or colon prefix ("mabl/debug", "mabl:debug") silently fails to load in Copilot`,
     );

--- a/.github/scripts/validate-skills.mjs
+++ b/.github/scripts/validate-skills.mjs
@@ -7,10 +7,10 @@
 //      truncates there, mid-word, so anything past it never reaches the matcher
 //      that decides whether the skill fires.
 //   3. Only the six frontmatter keys the Agent Skills spec allows.
-//   4. A body that routes to a sibling skill first has the reader confirm that
-//      skill is available — a skill can be installed on its own, and the skill
+//   4. A file that routes to a sibling skill declares it with
+//      "**Requires `<name>`.**" — a skill can be installed on its own, and it
 //      cannot know which of the five surfaces installed it, so it names the
-//      missing skill rather than an install command.
+//      skill it needs rather than an install command.
 // Exits non-zero with a clear message on any failure.
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
@@ -31,10 +31,12 @@ const DESCRIPTION_LIMIT = 1024;
 // Cursor.
 const SPEC_KEYS = ['name', 'description', 'license', 'compatibility', 'metadata', 'allowed-tools'];
 
-// The phrase a routing hand-off uses to make the reader check the sibling is
-// there. A fixed marker keeps check 4 greppable without asking CI to understand
-// prose.
-const AVAILABILITY_MARKER = 'in your available skills';
+// A hand-off declares its dependency with this token, naming the skill it needs.
+// A structural declaration rather than a sentence: CI can verify it exactly, it
+// reads as prose, it names the skill so the error message is right, and every
+// other word around it stays free to edit. What CI cannot verify is that the
+// fallback beside it is correct — that stays a review item.
+const requiresDeclaration = (sibling) => `**Requires \`${sibling}\`.**`;
 
 // Every .md under a skill folder, recursively, so a route stated in references/
 // is checked too.
@@ -200,9 +202,9 @@ for (const folder of skillNames) {
     for (const sibling of skillNames) {
       if (sibling === folder) continue;
       const mention = new RegExp(`(?<![a-z0-9-])${sibling}(?![a-z0-9-])`);
-      if (mention.test(text) && !text.includes(AVAILABILITY_MARKER)) {
+      if (mention.test(text) && !text.includes(requiresDeclaration(sibling))) {
         errors.push(
-          `${file}: names the sibling skill "${sibling}" but never has the reader confirm it is available — a skill can be installed on its own, so that pointer dangles for anyone who has only "${folder}"; add a check in this file saying to confirm "${sibling}" is "${AVAILABILITY_MARKER}" and to name it if it is missing, or reword the mention so nothing routes there (routing belongs in SKILL.md)`,
+          `${file}: names the sibling skill "${sibling}" but never declares it as a dependency — a skill can be installed on its own, so that pointer dangles for anyone who has only "${folder}"; add "${requiresDeclaration(sibling)}" in this file at the hand-off, followed by what to do when the skill isn't there, or reword the mention so nothing routes there (routing belongs in SKILL.md)`,
         );
       }
     }
@@ -216,5 +218,5 @@ if (errors.length) {
 }
 
 console.log(
-  `All ${skillNames.length} skills in plugins/mabl/skills/ are valid: name matches folder, description within ${DESCRIPTION_LIMIT} characters, spec-only frontmatter keys, and an availability check for every sibling it routes to.`,
+  `All ${skillNames.length} skills in plugins/mabl/skills/ are valid: name matches folder, description within ${DESCRIPTION_LIMIT} characters, spec-only frontmatter keys, and a declared dependency for every sibling it routes to.`,
 );

--- a/.github/scripts/validate-skills.mjs
+++ b/.github/scripts/validate-skills.mjs
@@ -12,7 +12,7 @@
 //      cannot know which of the five surfaces installed it, so it names the
 //      skill it needs rather than an install command.
 // Exits non-zero with a clear message on any failure.
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, lstatSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseFrontmatter } from './lib/frontmatter.mjs';
@@ -87,7 +87,10 @@ if (!existsSync(skillsRoot)) {
 // reaches the pattern below.
 const validSkillNames = skillNames.filter((folder) => {
   if (SKILL_NAME.test(folder)) return true;
-  errors.push(`plugins/mabl/skills/${folder}/: folder name must be lowercase letters, numbers and hyphens only`);
+  // JSON.stringify, not the raw name: this is the one place a rejected name is
+  // still printed, and a directory name may contain a newline, which would put
+  // attacker text at the start of a log line where Actions reads `::` commands.
+  errors.push(`plugins/mabl/skills/${JSON.stringify(folder)}: folder name must be lowercase letters, numbers and hyphens only`);
   return false;
 });
 
@@ -99,8 +102,19 @@ const mentionPatterns = new Map(
 for (const folder of validSkillNames) {
   const rel = `plugins/mabl/skills/${folder}/SKILL.md`;
   const path = join(skillsRoot, folder, 'SKILL.md');
-  if (!existsSync(path)) {
+  // lstat, so a symlink reports as itself rather than as its target. Same rule
+  // markdownFilesIn applies to the rest of the folder, and it binds harder here:
+  // a linked SKILL.md is the file `gh skill install` must copy, so a link out of
+  // the folder ships broken to every surface while validating green. Reading one
+  // would also let a PR aim this at any path on the runner, or at a FIFO that
+  // blocks until the job timeout.
+  const stat = lstatSync(path, { throwIfNoEntry: false });
+  if (!stat) {
     errors.push(`${rel} is missing — every skill folder needs a SKILL.md`);
+    continue;
+  }
+  if (!stat.isFile()) {
+    errors.push(`${rel} must be a regular file — a symlink or pipe here is not copied by \`gh skill install\``);
     continue;
   }
 

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -44,3 +44,10 @@ jobs:
       # in parity with the Claude manifest and the marketplace points at it.
       - name: Validate Codex cross-surface parity
         run: node .github/scripts/validate-codex-parity.mjs
+      # No validator checks the skills themselves against what the install
+      # surfaces require, so check that here: frontmatter name == folder name,
+      # a description short enough that Codex won't truncate it, only the keys
+      # the Agent Skills spec allows, and an install command for every sibling
+      # skill a body points at.
+      - name: Validate skills
+        run: node .github/scripts/validate-skills.mjs

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -5,9 +5,16 @@ on:
   push:
     branches: [main]
 
+# Every step only reads the checkout, so read-only is the whole grant.
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: 'ubuntu-latest'
+    # Seconds-long checks over PR-author-controlled files. A bound means a
+    # pathological input costs a minute, not the six-hour default.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 #v6.0.9
@@ -44,10 +51,16 @@ jobs:
       # in parity with the Claude manifest and the marketplace points at it.
       - name: Validate Codex cross-surface parity
         run: node .github/scripts/validate-codex-parity.mjs
+      # The frontmatter folding rules are what the description budget is
+      # measured against, so they get direct tests — and they run before the
+      # validator, so a broken reader can't green-light a PR.
+      - name: Test the frontmatter reader
+        run: node --test .github/scripts/lib/frontmatter.test.mjs
+
       # No validator checks the skills themselves against what the install
       # surfaces require, so check that here: frontmatter name == folder name,
       # a description short enough that Codex won't truncate it, only the keys
-      # the Agent Skills spec allows, and an install command for every sibling
-      # skill a body points at.
+      # the Agent Skills spec allows, and a declared dependency for every
+      # sibling skill a body routes to.
       - name: Validate skills
         run: node .github/scripts/validate-skills.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,12 +51,12 @@ the `version` field in `plugin.json` (kept in sync across all manifests — see
   with `get_test_definition`, which is the cloud planner's own tool, not yours;
   it now points at `mabl tests export`. And `mabl-test-edit`'s escape-hatch note
   no longer says "preview flags off".
-- The skills no longer name Runtime recovery. It's sunset, so a reader can't act
-  on the feature — only on the `recovered` status it left behind. That guidance
-  is deliberately unchanged: the CLI still parses and prints `recovered`, it's
-  still in the default trace filter, and a recovered step is still debugged the
-  same way as a failed one. What's gone is the feature as an actor, and the claim
-  about what new runs can produce.
+- Runtime recovery is gone from the skills entirely — the feature, the
+  `recovered` status, the recovery session id, and the claim about what new runs
+  can produce. It's sunset, so nothing about it is actionable: a status a reader
+  will never meet is worse than absent, because they stop and wonder what it is.
+  The step trace, the artifact envelope, and the test-vs-app routing table all
+  read as if failures are simply failures, which is now the only case.
 - "mablscript" is gone from the skills. It named the step format in three places
   where the reader only ever sees the consequence — a `legacy_unsupported` flow
   the structured lanes can't edit, or an export mabl refuses — so those now say

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ the `version` field in `plugin.json` (kept in sync across all manifests — see
 
 ## [1.6.1] - 2026-08-25
 ### Changed
+- `mabl-test-edit`'s description now fits the 1024-character budget every skill
+  matcher reads. It was 1201, and Codex truncates at 1024 mid-word, so the
+  boundary clause — that a just-authored test's validation gap is the authoring
+  skill's decision, and this skill should take the specifiable fixes it routes
+  over because a structured step edit is instant and can't delete anything —
+  was being cut off before any matcher saw it. Scope and sibling routing are
+  unchanged; one redundant trigger phrase was dropped.
+- Every skill that routes you to a sibling skill now checks the sibling is there
+  first. A skill can be installed on its own, so "route this to
+  `mabl-test-edit`" was a dead end for anyone who installed only the skill they
+  were reading. The two places it happens — test authoring to test edit, and
+  coverage design to test authoring — now confirm the sibling is available and
+  name it if it isn't, so you find out from the skill rather than from it
+  quietly doing nothing.
+- Three places named a sibling skill where nothing actually routes there:
+  `mabl-test-coverage-design` explained which Chrome `chrome-for-mabl` attaches
+  to by naming the skill that uses it, `mabl-test-edit` compared writing a
+  `test_case` to writing one for the authoring skill, and it cited `mabl-init` as
+  the source of a saved workspace it reads out of agent memory either way. All
+  three now say the thing itself.
 - `mabl-test-edit` no longer names mabl's internal feature flags when it explains
   which edit lanes a workspace has. The flag names were never usable: the skill
   says two lines later that an agent can't read a workspace's flags and has to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,12 +51,12 @@ the `version` field in `plugin.json` (kept in sync across all manifests — see
   with `get_test_definition`, which is the cloud planner's own tool, not yours;
   it now points at `mabl tests export`. And `mabl-test-edit`'s escape-hatch note
   no longer says "preview flags off".
-- `mabl-debug` no longer presents Runtime recovery as something that acts on your
-  runs. It's sunset, so the `recovered` status now reads as a status you'll
-  normally meet on older runs rather than as a feature salvaging steps. The
-  guidance is unchanged and deliberately kept: the CLI still parses and prints
-  `recovered`, the default trace still surfaces it, and a recovered step is still
-  debugged the same way as a failed one.
+- The skills no longer name Runtime recovery. It's sunset, so a reader can't act
+  on the feature — only on the `recovered` status it left behind. That guidance
+  is deliberately unchanged: the CLI still parses and prints `recovered`, it's
+  still in the default trace filter, and a recovered step is still debugged the
+  same way as a failed one. What's gone is the feature as an actor, and the claim
+  about what new runs can produce.
 - "mablscript" is gone from the skills. It named the step format in three places
   where the reader only ever sees the consequence — a `legacy_unsupported` flow
   the structured lanes can't edit, or an export mabl refuses — so those now say

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ the `version` field in `plugin.json` (kept in sync across all manifests — see
   `chrome-devtools` later. The caveat that matters is unchanged: `mabl agent
   install cursor` wires up two of the three MCP servers, so add the third by
   hand.
+- Four more places described mabl's internals rather than what you can see.
+  `mabl-debug` said a payload is absent on "TRA-recovered" runs — the status you
+  actually get is `recovered`, from Runtime recovery — and branched its step-id
+  guidance on whether a flow has persisted `json_steps` ids, which nothing you
+  can run reports; that branch is now the observable one, comparing the two id
+  strings before copying. `mabl-test-coverage-design` told you to open a test
+  with `get_test_definition`, which is the cloud planner's own tool, not yours;
+  it now points at `mabl tests export`. And `mabl-test-edit`'s escape-hatch note
+  no longer says "preview flags off".
 
 ## [1.6.0] - 2026-08-19
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ the `version` field in `plugin.json` (kept in sync across all manifests — see
   from a script in a repo you don't have. For an app-code fix the thing to
   rebuild is the app under test, and the reason to start a fresh session is an
   upgraded CLI — both now say so.
+- The Cursor install notes no longer promise that the CLI installer will pick up
+  `chrome-devtools` later. The caveat that matters is unchanged: `mabl agent
+  install cursor` wires up two of the three MCP servers, so add the third by
+  hand.
 
 ## [1.6.0] - 2026-08-19
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ the `version` field in `plugin.json` (kept in sync across all manifests — see
   with `get_test_definition`, which is the cloud planner's own tool, not yours;
   it now points at `mabl tests export`. And `mabl-test-edit`'s escape-hatch note
   no longer says "preview flags off".
+- "mablscript" is gone from the skills. It named the step format in three places
+  where the reader only ever sees the consequence — a `legacy_unsupported` flow
+  the structured lanes can't edit, or an export mabl refuses — so those now say
+  that instead.
 
 ## [1.6.0] - 2026-08-19
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,14 +51,14 @@ the `version` field in `plugin.json` (kept in sync across all manifests — see
   with `get_test_definition`, which is the cloud planner's own tool, not yours;
   it now points at `mabl tests export`. And `mabl-test-edit`'s escape-hatch note
   no longer says "preview flags off".
-- `mabl-debug` no longer explains Runtime recovery, only the status you can see.
-  The feature is sunset, so the sunset note, the recovery session id framing, and
-  the claim about what new runs can produce are gone. The `recovered` status
-  stays: `mabl agent debug steps` still filters to failed **and** recovered by
-  default, so a reader triaging an older run still meets it, and now gets one
-  paragraph on how to debug it instead of a history lesson. The triage recipe no
-  longer depends on knowing the full status list — it selects anything that isn't
-  passed or skipped, and stops loudly when there's nothing to triage.
+- Runtime recovery is gone from the skills — the feature, the `recovered` status
+  it left behind, and the recovery session id. It's sunset, so explaining it costs
+  every reader something to serve the shrinking few opening a run old enough to
+  carry it. Nothing is stranded: the triage recipe no longer depends on knowing
+  the status list at all. It selects any step that isn't passed or skipped — so it
+  still finds a recovered step without naming one — and stops loudly when there's
+  nothing to triage, instead of quietly passing an empty step id to three artifact
+  calls the way it briefly did.
 - The skills validator now has tests, and it needed them: the description budget
   it enforces was passing a 2789-character description clean, because a blank
   line inside a plain scalar ended the measurement instead of folding into it. A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ the `version` field in `plugin.json` (kept in sync across all manifests — see
   first. A skill can be installed on its own, so "route this to
   `mabl-test-edit`" was a dead end for anyone who installed only the skill they
   were reading. The two places it happens — test authoring to test edit, and
-  coverage design to test authoring — now confirm the sibling is available and
-  name it if it isn't, so you find out from the skill rather than from it
-  quietly doing nothing.
+  coverage design to test authoring — now declare it with **Requires
+  `<name>`** and say which skill is missing when it isn't there, so you find out
+  from the skill rather than from it quietly doing nothing.
 - Three places named a sibling skill where nothing actually routes there:
   `mabl-test-coverage-design` explained which Chrome `chrome-for-mabl` attaches
   to by naming the skill that uses it, `mabl-test-edit` compared writing a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the `mabl` plugin are documented here. Format follows
 the `version` field in `plugin.json` (kept in sync across all manifests — see
 `CLAUDE.md`).
 
+## [1.6.1] - 2026-08-25
+### Changed
+- `mabl-test-edit` no longer names mabl's internal feature flags when it explains
+  which edit lanes a workspace has. The flag names were never usable: the skill
+  says two lines later that an agent can't read a workspace's flags and has to
+  judge a lane by whether its tool is in the tool list. What that column was
+  really carrying — the lanes are gated **independently**, so one being closed
+  tells you nothing about the other — is now said outright, and the observable
+  signals (the tool list, the "contact mabl support" error) are unchanged.
+- `mabl-debug`'s fix-and-retry cycle no longer tells you to rebuild the mabl CLI
+  from a script in a repo you don't have. For an app-code fix the thing to
+  rebuild is the app under test, and the reason to start a fresh session is an
+  upgraded CLI — both now say so.
+
 ## [1.6.0] - 2026-08-19
 ### Changed
 - `mabl-test-coverage-design` now schedules the fan-out itself instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,12 +51,27 @@ the `version` field in `plugin.json` (kept in sync across all manifests — see
   with `get_test_definition`, which is the cloud planner's own tool, not yours;
   it now points at `mabl tests export`. And `mabl-test-edit`'s escape-hatch note
   no longer says "preview flags off".
-- Runtime recovery is gone from the skills entirely — the feature, the
-  `recovered` status, the recovery session id, and the claim about what new runs
-  can produce. It's sunset, so nothing about it is actionable: a status a reader
-  will never meet is worse than absent, because they stop and wonder what it is.
-  The step trace, the artifact envelope, and the test-vs-app routing table all
-  read as if failures are simply failures, which is now the only case.
+- `mabl-debug` no longer explains Runtime recovery, only the status you can see.
+  The feature is sunset, so the sunset note, the recovery session id framing, and
+  the claim about what new runs can produce are gone. The `recovered` status
+  stays: `mabl agent debug steps` still filters to failed **and** recovered by
+  default, so a reader triaging an older run still meets it, and now gets one
+  paragraph on how to debug it instead of a history lesson. The triage recipe no
+  longer depends on knowing the full status list — it selects anything that isn't
+  passed or skipped, and stops loudly when there's nothing to triage.
+- The skills validator now has tests, and it needed them: the description budget
+  it enforces was passing a 2789-character description clean, because a blank
+  line inside a plain scalar ended the measurement instead of folding into it. A
+  CRLF checkout also made every valid file report as having no frontmatter. The
+  reader moved to `.github/scripts/lib/frontmatter.mjs` so its folding rules can
+  be tested without running the validator, and CI runs those tests first.
+- The validator no longer trusts a folder name. A skill directory is
+  PR-author-controlled on a public repo and its name was compiled straight into a
+  pattern, so `evil(((` crashed the run before any finding printed and `(a+)+$`
+  backtracked past the six-hour job default. Names are now checked and escaped,
+  symlinks and vendored trees are skipped, an empty skills directory fails
+  instead of reporting "All 0 skills are valid", and the workflow runs read-only
+  with a ten-minute bound.
 - "mablscript" is gone from the skills. It named the step format in three places
   where the reader only ever sees the consequence — a `legacy_unsupported` flow
   the structured lanes can't edit, or an export mabl refuses — so those now say

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ the `version` field in `plugin.json` (kept in sync across all manifests — see
   with `get_test_definition`, which is the cloud planner's own tool, not yours;
   it now points at `mabl tests export`. And `mabl-test-edit`'s escape-hatch note
   no longer says "preview flags off".
+- `mabl-debug` no longer presents Runtime recovery as something that acts on your
+  runs. It's sunset, so the `recovered` status now reads as a status you'll
+  normally meet on older runs rather than as a feature salvaging steps. The
+  guidance is unchanged and deliberately kept: the CLI still parses and prints
+  `recovered`, the default trace still surfaces it, and a recovered step is still
+  debugged the same way as a failed one.
 - "mablscript" is gone from the skills. It named the step format in three places
   where the reader only ever sees the consequence — a `legacy_unsupported` flow
   the structured lanes can't edit, or an export mabl refuses — so those now say

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,8 @@ install it, because that depends on how this skill was installed.
 
 Don't name a sibling where nothing routes there — say the thing itself instead.
 
+**A `description` routes for the matcher, not mid-workflow, so it needs no declaration.** Six of the eight cross-skill references in this repo sit in frontmatter descriptions (`for CREATING a new test use mabl-test-authoring`), and CI deliberately exempts them: that text tells a reader they're in the wrong skill, it isn't a hand-off they depend on to finish a task. Forcing a declaration there would also spend the 1024-character budget the description is fighting for.
+
 **Routing lives in `SKILL.md`.** A `references/` file carries mechanics, not hand-offs — a reference restating a route is a second copy of a decision `SKILL.md` owns. CI checks every `.md` in the skill folder and wants the declaration in the *same file* as the mention, because a reference is loaded on its own and an agent acting from one may not have `SKILL.md` in context. A reference that trips this usually wants rewording rather than a second copy of the declaration.
 
 ### Folder name = frontmatter name
@@ -113,7 +115,8 @@ node .github/scripts/validate-copilot-manifest.mjs     # root plugin.json (Copil
 node scripts/validate-template.mjs                      # Cursor manifests (official validator)
 node .github/scripts/validate-cursor-parity.mjs        # mcp.json == .mcp.json + Cursor/Claude parity
 node .github/scripts/validate-codex-parity.mjs         # Codex/Claude manifest parity + marketplace
-node .github/scripts/validate-skills.mjs               # skill frontmatter, description budget, sibling install commands
+node --test .github/scripts/lib/frontmatter.test.mjs    # the frontmatter reader's folding rules
+node .github/scripts/validate-skills.mjs               # skill frontmatter, description budget, sibling dependency declarations
 ```
 
 `scripts/validate-template.mjs` is vendored verbatim from [`cursor/plugin-template`](https://github.com/cursor/plugin-template) — it's the validator the Cursor team's submission checklist runs. Keep it in sync if that upstream script changes. Its "no hooks/hooks.json" line is an expected warning (we ship no hooks), not an error.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,29 @@ This repo is public — external developers read our PRs. Write them short and h
 
 `gh skill install` copies ONE skill folder at a time. Anything a skill needs (references, scripts, version pins) must live inside its own `plugins/mabl/skills/<name>/` folder. Never reference files from outside the skill folder.
 
+For the same reason, a body that routes the reader to a **sibling skill** has to confirm that skill is there first — someone who installed only the skill they're reading has no other copy to route to. Keep the block to three lines, at the place the reference actually happens:
+
+```markdown
+**Confirm `mabl-test-edit` is in your available skills before routing the fix
+there.** If it isn't, stop and tell the user which skill is missing by name —
+don't attempt the edit yourself, and don't guess how to install it.
+```
+
+**Name the missing skill, never an install command.** A skill cannot know which of the five surfaces installed it, so `gh skill install ...` is wrong guidance for the four readers who used a marketplace instead. Report what's missing and let the user install it their way.
+
+Don't name a sibling where nothing routes there — say the thing itself instead. CI checks that every sibling named in a body is accompanied by that availability check.
+
 ### Folder name = frontmatter name
 
-The frontmatter `name` in `SKILL.md` must match the folder name exactly, lowercase with hyphens. Mismatched or prefixed names (`mabl/debug`, `mabl:debug`) silently fail to load in Copilot.
+The frontmatter `name` in `SKILL.md` must match the folder name exactly, lowercase with hyphens. Mismatched or prefixed names (`mabl/debug`, `mabl:debug`) silently fail to load in Copilot. CI checks this.
+
+### Descriptions have a 1024-character budget
+
+OpenAI Codex hard-truncates a skill description at 1024 characters, mid-word, so anything past that never reaches the matcher that decides whether the skill fires. CI measures the description the way a YAML loader resolves it — a block scalar joined into one line — and fails over budget. Front-load scope and triggers, and keep boundary clauses and negative triggers ahead of anything optional so truncation can't eat them.
+
+### Frontmatter carries only the six spec keys
+
+`name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools` — the full list the Agent Skills spec allows. Any other key makes claude.ai skill upload, the Skills API, and `package_skill.py` fail with a hard "Unexpected key(s)" error, so Claude Code-only fields (`disable-model-invocation`, `user-invocable`, `model`, `context`, `hooks`) stay out; a plugin-delivered skill carrying `disable-model-invocation` is also invisible in Cursor. CI checks this.
 
 ### Every skill starts with the mabl CLI prerequisite block
 
@@ -89,6 +109,7 @@ node .github/scripts/validate-copilot-manifest.mjs     # root plugin.json (Copil
 node scripts/validate-template.mjs                      # Cursor manifests (official validator)
 node .github/scripts/validate-cursor-parity.mjs        # mcp.json == .mcp.json + Cursor/Claude parity
 node .github/scripts/validate-codex-parity.mjs         # Codex/Claude manifest parity + marketplace
+node .github/scripts/validate-skills.mjs               # skill frontmatter, description budget, sibling install commands
 ```
 
 `scripts/validate-template.mjs` is vendored verbatim from [`cursor/plugin-template`](https://github.com/cursor/plugin-template) — it's the validator the Cursor team's submission checklist runs. Keep it in sync if that upstream script changes. Its "no hooks/hooks.json" line is an expected warning (we ship no hooks), not an error.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,9 @@ don't attempt the edit yourself, and don't guess how to install it.
 
 **Name the missing skill, never an install command.** A skill cannot know which of the five surfaces installed it, so `gh skill install ...` is wrong guidance for the four readers who used a marketplace instead. Report what's missing and let the user install it their way.
 
-Don't name a sibling where nothing routes there — say the thing itself instead. CI checks that every sibling named in a body is accompanied by that availability check.
+Don't name a sibling where nothing routes there — say the thing itself instead.
+
+**Routing lives in `SKILL.md`.** A `references/` file carries mechanics, not hand-offs — a reference restating a route is a second copy of a decision `SKILL.md` owns. CI checks every `.md` in the skill folder and wants the availability check in the *same file* as the mention, because a reference is loaded on its own and an agent acting from one may not have `SKILL.md` in context. A reference that trips this usually wants rewording rather than a second copy of the check.
 
 ### Folder name = frontmatter name
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,4 +103,6 @@ To test the Codex plugin: `codex plugin marketplace add .` (or `mablhq/skills`) 
 
 ## Syncing with mabl-cli
 
-The skills originated from `mabl-cli` (`runtime/src/resources/skills/`). Content fixes that apply there too should be synced back in a follow-up PR on mabl-cli.
+These skills also ship inside the mabl CLI. mabl keeps the two copies in sync, so an outside contributor has nothing extra to do — fix it here.
+
+mabl maintainers: mirror content fixes into the CLI's copy in a follow-up PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,16 +65,18 @@ This repo is public — external developers read our PRs. Write them short and h
 For the same reason, a body that routes the reader to a **sibling skill** has to confirm that skill is there first — someone who installed only the skill they're reading has no other copy to route to. Keep the block to three lines, at the place the reference actually happens:
 
 ```markdown
-**Confirm `mabl-test-edit` is in your available skills before routing the fix
-there.** If it isn't, stop and tell the user which skill is missing by name —
-don't attempt the edit yourself, and don't guess how to install it.
+**Requires `mabl-test-edit`.** If that skill isn't there, stop and say which
+skill is missing — don't attempt the edit yourself, and don't guess how to
+install it, because that depends on how this skill was installed.
 ```
+
+**`**Requires \`<name>\`.**` is the checked token.** A structural declaration, not a sentence: CI verifies it exactly, it reads as prose, and it names the skill so the error message is right. Every other word around it is free to edit. What CI can't verify is that the fallback beside it is correct — that stays a review item.
 
 **Name the missing skill, never an install command.** A skill cannot know which of the five surfaces installed it, so `gh skill install ...` is wrong guidance for the four readers who used a marketplace instead. Report what's missing and let the user install it their way.
 
 Don't name a sibling where nothing routes there — say the thing itself instead.
 
-**Routing lives in `SKILL.md`.** A `references/` file carries mechanics, not hand-offs — a reference restating a route is a second copy of a decision `SKILL.md` owns. CI checks every `.md` in the skill folder and wants the availability check in the *same file* as the mention, because a reference is loaded on its own and an agent acting from one may not have `SKILL.md` in context. A reference that trips this usually wants rewording rather than a second copy of the check.
+**Routing lives in `SKILL.md`.** A `references/` file carries mechanics, not hand-offs — a reference restating a route is a second copy of a decision `SKILL.md` owns. CI checks every `.md` in the skill folder and wants the declaration in the *same file* as the mention, because a reference is loaded on its own and an agent acting from one may not have `SKILL.md` in context. A reference that trips this usually wants rewording rather than a second copy of the declaration.
 
 ### Folder name = frontmatter name
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The repo is also a Cursor plugin (`.cursor-plugin/`). It installs through a Curs
 2. Enter the repo URL: `https://github.com/mablhq/skills`
 3. Developers then install `mabl` from the **Customize** panel in the Cursor sidebar.
 
-Skills and all three MCP servers are configured in one step. For a quick per-project setup without a marketplace, run `mabl agent install cursor` from the mabl CLI instead — it currently wires up `chrome-for-mabl` and `mabl` only, so add `chrome-devtools` by hand (see the `gh skill install` JSON below) until the CLI installer picks it up too.
+Skills and all three MCP servers are configured in one step. For a quick per-project setup without a marketplace, run `mabl agent install cursor` from the mabl CLI instead — it currently wires up `chrome-for-mabl` and `mabl` only, so add `chrome-devtools` by hand (see the `gh skill install` JSON below).
 
 ### GitHub Copilot in VS Code
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mabl",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
   "author": {
     "name": "mabl",

--- a/plugins/mabl/.claude-plugin/plugin.json
+++ b/plugins/mabl/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mabl",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "mabl",
     "email": "support@mabl.com",

--- a/plugins/mabl/.codex-plugin/plugin.json
+++ b/plugins/mabl/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mabl",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
   "author": {
     "name": "mabl",

--- a/plugins/mabl/.cursor-plugin/plugin.json
+++ b/plugins/mabl/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mabl",
   "displayName": "mabl",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Independent verification for agentic development. Create, run, and debug mabl end-to-end tests directly from your coding agent.",
   "author": {
     "name": "mabl",

--- a/plugins/mabl/skills/mabl-debug/SKILL.md
+++ b/plugins/mabl/skills/mabl-debug/SKILL.md
@@ -407,16 +407,15 @@ stdout) is your green check.
 **Reuse vs. restart.** Keep using the same `<sid>` while iterating —
 the session holds the browser, cookies, and state from earlier steps,
 which is what you want. Start a fresh `session start --run-id <jr-id>`
-only when (a) the fix changed code the runtime loads at startup (a CLI
-rebuild, an executor change), (b) the browser is in a bad state you
-can't unstick, or (c) you want a clean reproduction to attach to the
-PR.
+only when (a) you upgraded the mabl CLI, since the runtime is loaded
+at startup, (b) the browser is in a bad state you can't unstick, or
+(c) you want a clean reproduction to attach to the PR.
 
-For app-code fixes, the productive cycle is: edit → rebuild CLI (see
-`build:local` in CLAUDE.md) → fresh `session start` → `run-to-step` →
-`run-step` on the failing id. For test-only fixes (selector, wait,
-assertion), no rebuild is needed — update the test definition and
-`run-step` directly.
+For app-code fixes, the productive cycle is: edit → rebuild the app
+under test → fresh `session start` → `run-to-step` → `run-step` on
+the failing id. For test-only fixes (selector, wait, assertion), no
+rebuild is needed — update the test definition and `run-step`
+directly.
 
 ---
 

--- a/plugins/mabl/skills/mabl-debug/SKILL.md
+++ b/plugins/mabl/skills/mabl-debug/SKILL.md
@@ -74,30 +74,27 @@ a real browser the agent drives directly.
 > shape that this CLI surface doesn't cover.
 
 ```bash
-# Step trace, default. Output is the failed steps and any recovered
-# steps (plus the summary block) — see "Recovered steps" below. Pass
-# --all to see passed / skipped steps as well.
+# Step trace, default. Output is the failed steps plus the summary
+# block. Pass --all to see passed / skipped steps as well.
 mabl agent debug steps <jr-id>
 mabl agent debug steps <jr-id> --all   # full trace
 ```
 
 When the default trace hides entries, it tells you so via a top-level
-`note` field — the exact string is `"Filtered to failed/recovered
-steps (N hidden). Pass --all to see the full trace."`. Treat that as
-"the run executed more than the failed step, you just don't need to
-see the noise yet."
+`note` field saying how many it hid and that `--all` shows them. Treat
+that as "the run executed more than the failed step, you just don't
+need to see the noise yet."
 
 Each entry has `index` (1-based), `step_run_id`, `flow`, `action`,
-`description`, `status` (`passed` / `failed` / `skipped` /
-`recovered`), `duration_ms`, `step_id` (per-flow — feed to live-session
-commands), and `step_id_in_test` (per-test). The trace also carries a
-top-level `summary` block on any failed-or-recovered run; on those it
-also includes `summary.step_id` — that's the value to copy straight
-into `debug session run-step` / `run-to-step` after triage. The
-top-level summary is the one to scan first; the API-side
-`failure_summary` payload (where `step_id_in_test` originates) is only
-present on hard failures, not on runs that recovered. `step_run_id` is
-what every `artifact` call below takes.
+`description`, `status` (`passed` / `failed` / `skipped`),
+`duration_ms`, `step_id` (per-flow — feed to live-session commands),
+and `step_id_in_test` (per-test). The trace also carries a top-level
+`summary` block on any failed run; on those it also includes
+`summary.step_id` — that's the value to copy straight into
+`debug session run-step` / `run-to-step` after triage. The top-level
+summary is the one to scan first; the API-side `failure_summary`
+payload (where `step_id_in_test` originates) is only present on hard
+failures. `step_run_id` is what every `artifact` call below takes.
 
 ```bash
 # Drill into one artifact for the failing step.
@@ -149,7 +146,7 @@ Example — full triage of a failing click:
 
 ```bash
 SID=$(mabl agent debug steps abc123-jr --output json \
-  | jq -r '.steps[] | select(.status == "failed" or .status == "recovered") | .step_run_id' | head -1)
+  | jq -r '.steps[] | select(.status == "failed") | .step_run_id' | head -1)
 
 # What did the network look like at the failing step?
 mabl agent debug artifact network abc123-jr --step-run-id "$SID" \
@@ -165,22 +162,6 @@ mabl agent debug artifact console abc123-jr --step-run-id "$SID" \
 
 Artifacts cache to `.mabl/debug/<jr-id>/` (gitignored) and are reused
 across calls.
-
-### Recovered steps
-
-A step with `status: "recovered"` is a step that **failed**, then was
-recovered so the run could continue. You'll normally meet it only on
-older runs, which the default trace still surfaces. The status is
-`recovered` rather than `passed` precisely because it marked a real
-bug: the recovery papered over it for that run, but the underlying
-cause stayed.
-
-Debug a recovered step the same way as a failed one: the step's own
-find/assert failure is the signal, and the fix is either the test (a
-stale selector, a missing wait, a wrong assertion) or the app (a
-regressed precondition).
-
----
 
 ## 2. Hypothesize — map the failure to code
 
@@ -207,7 +188,7 @@ heuristic:
 | Signal | Likely owner |
 |---|---|
 | Stack trace points into product source; failed network call to an app endpoint; new uncaught JS error after a recent deploy | **App** — `git log <last_passing_deploy>..HEAD` on the relevant repo, then file/fix in product code |
-| `status: "recovered"`; stale `data-testid`; assertion expects a value the app never produced | **Test** — update the step / selector / assertion in the mabl test |
+| Stale `data-testid`; assertion expects a value the app never produced | **Test** — update the step / selector / assertion in the mabl test |
 | Test flakes on retry but app code, DOM, and network all look healthy | **Test** — usually a missing wait or a timing assumption |
 
 When in doubt, run the live session (§3) and step through — a real
@@ -261,7 +242,7 @@ The `stepCount` field on the session-start envelope is the size of the
 fully-expanded runtime step list (top-level + every nested
 EvaluateFlow / StepGroup child). The forensic `debug steps` trace
 reports `total_steps` for the steps the run actually executed — which
-is normally smaller because branches, recovered shortcuts, or early
+is normally smaller because branches or an early
 failures stop the walk before every nested step runs. The two numbers
 describing the same test will disagree by design; don't try to
 reconcile them.

--- a/plugins/mabl/skills/mabl-debug/SKILL.md
+++ b/plugins/mabl/skills/mabl-debug/SKILL.md
@@ -74,9 +74,9 @@ a real browser the agent drives directly.
 > shape that this CLI surface doesn't cover.
 
 ```bash
-# Step trace, default. Output is the failed steps and the steps that
-# Runtime recovery recovered (plus the summary block). Pass --all if
-# you need to see passed / skipped steps as well.
+# Step trace, default. Output is the failed steps and any recovered
+# steps (plus the summary block) — see "Recovered steps" below. Pass
+# --all to see passed / skipped steps as well.
 mabl agent debug steps <jr-id>
 mabl agent debug steps <jr-id> --all   # full trace
 ```
@@ -170,11 +170,11 @@ across calls.
 ### Recovered steps
 
 A step with `status: "recovered"` is a step that **failed**, then was
-salvaged by Runtime recovery so the run could continue. Runtime
-recovery is sunset, so no new run produces this status, but the default
-trace still surfaces it on older runs. The status is `recovered` rather
-than `passed` precisely because it marked a real bug: recovery papered
-over it for that run, but the underlying cause stayed.
+recovered so the run could continue. Runtime recovery is sunset, so
+you'll normally only see this on older runs, which the default trace
+still surfaces. The status is `recovered` rather than `passed`
+precisely because it marked a real bug: recovery papered over it for
+that run, but the underlying cause stayed.
 
 Debug a recovered step the same way as a failed one: the step's own
 find/assert failure is the signal, and the fix is either the test (a

--- a/plugins/mabl/skills/mabl-debug/SKILL.md
+++ b/plugins/mabl/skills/mabl-debug/SKILL.md
@@ -96,7 +96,8 @@ also includes `summary.step_id` — that's the value to copy straight
 into `debug session run-step` / `run-to-step` after triage. The
 top-level summary is the one to scan first; the API-side
 `failure_summary` payload (where `step_id_in_test` originates) is only
-present on hard failures, not on TRA-recovered runs. `step_run_id` is
+present on hard failures, not on runs Runtime recovery salvaged.
+`step_run_id` is
 what every `artifact` call below takes.
 
 ```bash
@@ -444,19 +445,19 @@ from triage to a `run-to-step`, copy `step_id` (not `step_id_in_test`).
 `debug session list-steps` shows `step_id` under the `id` field.
 
 **`step_id` is *usually* stable across the two surfaces — but not
-always.** When flows have persisted `json_steps` ids, the `step_id`
-string `debug steps` prints is the same one `list-steps` shows under
-`id` and the same one `run-step` / `run-to-step` / `set-current-step`
-accept. Direct copy, no translation.
+always.** Most of the time the `step_id` string `debug steps` prints
+is the same one `list-steps` shows under `id` and the same one
+`run-step` / `run-to-step` / `set-current-step` accept. Direct copy,
+no translation.
 
-For flows whose `json_steps` lack ids (older tests, freshly imported
-flows, some training paths), the two surfaces address the same step
-through different ids: `debug steps` prints whatever runtime stepId
-the trace recorded, and `list-steps` falls back to a synthetic
-`<flow-id>:<flat-index>` shape. Those strings won't match each other.
-**When you can't copy `step_id` straight through, address the live
-step by `position` instead** — `list-steps` always emits one
-(`"3"`, `"3.2"`) and every live command accepts it.
+On some tests — older ones, and freshly imported flows — the two
+surfaces address the same step through different ids: `debug steps`
+prints whatever runtime stepId the trace recorded, and `list-steps`
+falls back to a synthetic `<flow-id>:<flat-index>` shape. Those
+strings won't match each other, so **compare them before you copy.**
+If the `id` in `list-steps` isn't the `step_id` the trace gave you,
+address the live step by `position` instead — `list-steps` always
+emits one (`"3"`, `"3.2"`) and every live command accepts it.
 
 `set-current-step`'s JSON response includes a `stepId` field that's
 always the addressable form (canonical or synthetic) — safe to feed

--- a/plugins/mabl/skills/mabl-debug/SKILL.md
+++ b/plugins/mabl/skills/mabl-debug/SKILL.md
@@ -74,8 +74,8 @@ a real browser the agent drives directly.
 > shape that this CLI surface doesn't cover.
 
 ```bash
-# Step trace, default. Output is the failed and recovered steps plus
-# the summary block. Pass --all to see passed / skipped steps too.
+# Step trace, default. Output is the steps that didn't pass, plus the
+# summary block. Pass --all to see passed / skipped steps too.
 mabl agent debug steps <jr-id>
 mabl agent debug steps <jr-id> --all   # full trace
 ```
@@ -86,11 +86,11 @@ that as "the run executed more than the failed step, you just don't
 need to see the noise yet."
 
 Each entry has `index` (1-based), `step_run_id`, `flow`, `action`,
-`description`, `status` (`passed` / `failed` / `skipped` /
-`recovered`), `duration_ms`, `step_id` (per-flow — feed to
-live-session commands), and `step_id_in_test` (per-test). The trace
-also carries a top-level `summary` block on any run with a failed or
-recovered step; on those it also includes
+`description`, `status` (`passed` / `failed` / `skipped`),
+`duration_ms`, `step_id` (per-flow — feed to live-session commands),
+and `step_id_in_test` (per-test). The trace also carries a top-level
+`summary` block on any run with a step that didn't pass; on those it
+also includes
 `summary.step_id` — that's the value to copy straight into
 `debug session run-step` / `run-to-step` after triage. The top-level
 summary is the one to scan first; the API-side `failure_summary`
@@ -165,17 +165,6 @@ mabl agent debug artifact console abc123-jr --step-run-id "$SID" \
 Artifacts cache to `.mabl/debug/<jr-id>/` (gitignored) and are reused
 across calls.
 
-### Recovered steps
-
-A step with `status: "recovered"` failed and was then salvaged mid-run
-so the run could continue. The status is `recovered` rather than
-`passed` precisely because it marked a real bug. Debug it the same way
-as a failed one: the step's own find/assert failure is the signal, and
-the fix is either the test (a stale selector, a missing wait, a wrong
-assertion) or the app (a regressed precondition).
-
----
-
 ## 2. Hypothesize — map the failure to code
 
 The triage output gives you names that ground the search:
@@ -201,7 +190,7 @@ heuristic:
 | Signal | Likely owner |
 |---|---|
 | Stack trace points into product source; failed network call to an app endpoint; new uncaught JS error after a recent deploy | **App** — `git log <last_passing_deploy>..HEAD` on the relevant repo, then file/fix in product code |
-| `status: "recovered"`; stale `data-testid`; assertion expects a value the app never produced | **Test** — update the step / selector / assertion in the mabl test |
+| Stale `data-testid`; assertion expects a value the app never produced | **Test** — update the step / selector / assertion in the mabl test |
 | Test flakes on retry but app code, DOM, and network all look healthy | **Test** — usually a missing wait or a timing assumption |
 
 When in doubt, run the live session (§3) and step through — a real

--- a/plugins/mabl/skills/mabl-debug/SKILL.md
+++ b/plugins/mabl/skills/mabl-debug/SKILL.md
@@ -86,8 +86,10 @@ that as "the run executed more than the failed step, you just don't
 need to see the noise yet."
 
 Each entry has `index` (1-based), `step_run_id`, `flow`, `action`,
-`description`, `status` (`passed` / `failed` / `skipped`),
-`duration_ms`, `step_id` (per-flow — feed to live-session commands),
+`description`, `status` (usually `passed` / `failed` / `skipped` —
+match it as *not* `passed` and *not* `skipped` rather than comparing to
+`failed`, the way the recipe below does), `duration_ms`, `step_id`
+(per-flow — feed to live-session commands),
 and `step_id_in_test` (per-test). The trace also carries a top-level
 `summary` block on any run with a step that didn't pass; on those it
 also includes

--- a/plugins/mabl/skills/mabl-debug/SKILL.md
+++ b/plugins/mabl/skills/mabl-debug/SKILL.md
@@ -74,8 +74,8 @@ a real browser the agent drives directly.
 > shape that this CLI surface doesn't cover.
 
 ```bash
-# Step trace, default. Output is the failed steps plus the summary
-# block. Pass --all to see passed / skipped steps as well.
+# Step trace, default. Output is the failed and recovered steps plus
+# the summary block. Pass --all to see passed / skipped steps too.
 mabl agent debug steps <jr-id>
 mabl agent debug steps <jr-id> --all   # full trace
 ```
@@ -86,10 +86,11 @@ that as "the run executed more than the failed step, you just don't
 need to see the noise yet."
 
 Each entry has `index` (1-based), `step_run_id`, `flow`, `action`,
-`description`, `status` (`passed` / `failed` / `skipped`),
-`duration_ms`, `step_id` (per-flow — feed to live-session commands),
-and `step_id_in_test` (per-test). The trace also carries a top-level
-`summary` block on any failed run; on those it also includes
+`description`, `status` (`passed` / `failed` / `skipped` /
+`recovered`), `duration_ms`, `step_id` (per-flow — feed to
+live-session commands), and `step_id_in_test` (per-test). The trace
+also carries a top-level `summary` block on any run with a failed or
+recovered step; on those it also includes
 `summary.step_id` — that's the value to copy straight into
 `debug session run-step` / `run-to-step` after triage. The top-level
 summary is the one to scan first; the API-side `failure_summary`
@@ -146,7 +147,8 @@ Example — full triage of a failing click:
 
 ```bash
 SID=$(mabl agent debug steps abc123-jr --output json \
-  | jq -r '.steps[] | select(.status == "failed") | .step_run_id' | head -1)
+  | jq -r '.steps[] | select(.status != "passed" and .status != "skipped") | .step_run_id' | head -1)
+[ -n "$SID" ] || { echo "no non-passing step in the trace — read the summary block first"; exit 1; }
 
 # What did the network look like at the failing step?
 mabl agent debug artifact network abc123-jr --step-run-id "$SID" \
@@ -162,6 +164,17 @@ mabl agent debug artifact console abc123-jr --step-run-id "$SID" \
 
 Artifacts cache to `.mabl/debug/<jr-id>/` (gitignored) and are reused
 across calls.
+
+### Recovered steps
+
+A step with `status: "recovered"` failed and was then salvaged mid-run
+so the run could continue. The status is `recovered` rather than
+`passed` precisely because it marked a real bug. Debug it the same way
+as a failed one: the step's own find/assert failure is the signal, and
+the fix is either the test (a stale selector, a missing wait, a wrong
+assertion) or the app (a regressed precondition).
+
+---
 
 ## 2. Hypothesize — map the failure to code
 
@@ -188,7 +201,7 @@ heuristic:
 | Signal | Likely owner |
 |---|---|
 | Stack trace points into product source; failed network call to an app endpoint; new uncaught JS error after a recent deploy | **App** — `git log <last_passing_deploy>..HEAD` on the relevant repo, then file/fix in product code |
-| Stale `data-testid`; assertion expects a value the app never produced | **Test** — update the step / selector / assertion in the mabl test |
+| `status: "recovered"`; stale `data-testid`; assertion expects a value the app never produced | **Test** — update the step / selector / assertion in the mabl test |
 | Test flakes on retry but app code, DOM, and network all look healthy | **Test** — usually a missing wait or a timing assumption |
 
 When in doubt, run the live session (§3) and step through — a real
@@ -242,8 +255,8 @@ The `stepCount` field on the session-start envelope is the size of the
 fully-expanded runtime step list (top-level + every nested
 EvaluateFlow / StepGroup child). The forensic `debug steps` trace
 reports `total_steps` for the steps the run actually executed — which
-is normally smaller because branches or an early
-failures stop the walk before every nested step runs. The two numbers
+is normally smaller because a branch or an early failure stops the
+walk before every nested step runs. The two numbers
 describing the same test will disagree by design; don't try to
 reconcile them.
 

--- a/plugins/mabl/skills/mabl-debug/SKILL.md
+++ b/plugins/mabl/skills/mabl-debug/SKILL.md
@@ -96,8 +96,7 @@ also includes `summary.step_id` — that's the value to copy straight
 into `debug session run-step` / `run-to-step` after triage. The
 top-level summary is the one to scan first; the API-side
 `failure_summary` payload (where `step_id_in_test` originates) is only
-present on hard failures, not on runs Runtime recovery salvaged.
-`step_run_id` is
+present on hard failures, not on runs that recovered. `step_run_id` is
 what every `artifact` call below takes.
 
 ```bash
@@ -170,11 +169,11 @@ across calls.
 ### Recovered steps
 
 A step with `status: "recovered"` is a step that **failed**, then was
-recovered so the run could continue. Runtime recovery is sunset, so
-you'll normally only see this on older runs, which the default trace
-still surfaces. The status is `recovered` rather than `passed`
-precisely because it marked a real bug: recovery papered over it for
-that run, but the underlying cause stayed.
+recovered so the run could continue. You'll normally meet it only on
+older runs, which the default trace still surfaces. The status is
+`recovered` rather than `passed` precisely because it marked a real
+bug: the recovery papered over it for that run, but the underlying
+cause stayed.
 
 Debug a recovered step the same way as a failed one: the step's own
 find/assert failure is the signal, and the fix is either the test (a

--- a/plugins/mabl/skills/mabl-debug/references/command-reference.md
+++ b/plugins/mabl/skills/mabl-debug/references/command-reference.md
@@ -15,12 +15,10 @@ Below: artifact shape, install targets, and common runtime errors.
 `mabl agent debug steps <jr-id>` emits a `steps[]` array (YAML by
 default for readability; pass `--output json` when piping to tooling).
 Each entry carries `index` (1-based), `step_run_id`, `flow`, `action`,
-`description`, `status` (`passed` / `failed` / `skipped` /
-`recovered`), `duration_ms`, `step_number_in_flow`,
-`step_id_in_test`, optional `url_before` / `url_after`, an `error`
-block on failed and recovered entries, an optional
-`recovery.session_id` on recovered entries, and the list of
-artifact types captured for that
+`description`, `status` (`passed` / `failed` / `skipped`),
+`duration_ms`, `step_number_in_flow`, `step_id_in_test`,
+optional `url_before` / `url_after`, an `error` block on
+failed entries, and the list of artifact types captured for that
 step. The trace also carries `total_steps` (unfiltered count),
 `displayed_steps` (when filtering hid entries), and a top-level
 `summary` block reflecting `failure_summary` from the API.

--- a/plugins/mabl/skills/mabl-debug/references/command-reference.md
+++ b/plugins/mabl/skills/mabl-debug/references/command-reference.md
@@ -68,7 +68,7 @@ mabl agent debug artifact screenshot foo-jr --step-run-id step-1 --before
 ```
 
 Artifacts cache to `.mabl/debug/<jr-id>/`. Re-running the same call is
-free; you can also bypass the CLI and read the cached file directly
+free; bypassing the CLI to read the cached file directly works too,
 once you know its path.
 
 ---

--- a/plugins/mabl/skills/mabl-debug/references/command-reference.md
+++ b/plugins/mabl/skills/mabl-debug/references/command-reference.md
@@ -15,7 +15,8 @@ Below: artifact shape, install targets, and common runtime errors.
 `mabl agent debug steps <jr-id>` emits a `steps[]` array (YAML by
 default for readability; pass `--output json` when piping to tooling).
 Each entry carries `index` (1-based), `step_run_id`, `flow`, `action`,
-`description`, `status` (`passed` / `failed` / `skipped`),
+`description`, `status` (usually `passed` / `failed` / `skipped`; match
+on *not* `passed` and *not* `skipped` rather than on `failed`),
 `duration_ms`, `step_number_in_flow`, `step_id_in_test`,
 optional `url_before` / `url_after`, an `error` block on
 failed entries, and the list of artifact types captured for that

--- a/plugins/mabl/skills/mabl-debug/references/command-reference.md
+++ b/plugins/mabl/skills/mabl-debug/references/command-reference.md
@@ -15,10 +15,12 @@ Below: artifact shape, install targets, and common runtime errors.
 `mabl agent debug steps <jr-id>` emits a `steps[]` array (YAML by
 default for readability; pass `--output json` when piping to tooling).
 Each entry carries `index` (1-based), `step_run_id`, `flow`, `action`,
-`description`, `status` (`passed` / `failed` / `skipped`),
-`duration_ms`, `step_number_in_flow`, `step_id_in_test`,
-optional `url_before` / `url_after`, an `error` block on
-failed entries, and the list of artifact types captured for that
+`description`, `status` (`passed` / `failed` / `skipped` /
+`recovered`), `duration_ms`, `step_number_in_flow`,
+`step_id_in_test`, optional `url_before` / `url_after`, an `error`
+block on failed and recovered entries, an optional
+`recovery.session_id` on recovered entries, and the list of
+artifact types captured for that
 step. The trace also carries `total_steps` (unfiltered count),
 `displayed_steps` (when filtering hid entries), and a top-level
 `summary` block reflecting `failure_summary` from the API.
@@ -67,7 +69,7 @@ mabl agent debug artifact screenshot foo-jr --step-run-id step-1 --before
 ```
 
 Artifacts cache to `.mabl/debug/<jr-id>/`. Re-running the same call is
-free; bypassing the CLI to read the cached file directly works too,
+free; you can also bypass the CLI and read the cached file directly
 once you know its path.
 
 ---

--- a/plugins/mabl/skills/mabl-debug/references/command-reference.md
+++ b/plugins/mabl/skills/mabl-debug/references/command-reference.md
@@ -15,11 +15,10 @@ Below: artifact shape, install targets, and common runtime errors.
 `mabl agent debug steps <jr-id>` emits a `steps[]` array (YAML by
 default for readability; pass `--output json` when piping to tooling).
 Each entry carries `index` (1-based), `step_run_id`, `flow`, `action`,
-`description`, `status` (`passed` / `failed` / `skipped` /
-`recovered`), `duration_ms`, `step_number_in_flow`, `step_id_in_test`,
+`description`, `status` (`passed` / `failed` / `skipped`),
+`duration_ms`, `step_number_in_flow`, `step_id_in_test`,
 optional `url_before` / `url_after`, an `error` block on
-failed/recovered entries, an optional `recovery.session_id` on
-recovered entries, and the list of artifact types captured for that
+failed entries, and the list of artifact types captured for that
 step. The trace also carries `total_steps` (unfiltered count),
 `displayed_steps` (when filtering hid entries), and a top-level
 `summary` block reflecting `failure_summary` from the API.

--- a/plugins/mabl/skills/mabl-test-authoring/SKILL.md
+++ b/plugins/mabl/skills/mabl-test-authoring/SKILL.md
@@ -67,7 +67,7 @@ to the session; `status` surfaces its id plus a `viewTestRunUrl`. So:
 - **absent** → nothing proved the test works. Either the validation didn't
   pass, or the workspace can't report agent runs. Treat the test as unverified.
 
-Other things to do with the test:
+Other things you can do with the test:
 
 - **Run the test in the cloud:** `mabl tests run-cloud --id <createdTestId>`
 - **Run the test locally:** `mabl tests run --id <createdTestId>`

--- a/plugins/mabl/skills/mabl-test-authoring/SKILL.md
+++ b/plugins/mabl/skills/mabl-test-authoring/SKILL.md
@@ -440,9 +440,9 @@ the `mabl-test-edit` skill's structured-step lane, which applies a named
 That lane is not just faster. **A structured insert cannot delete anything**, so
 it removes the whole risk this section is guarding against.
 
-**Confirm `mabl-test-edit` is in your available skills before routing the fix
-there.** If it isn't, stop and tell the user which skill is missing by name —
-don't attempt the edit yourself, and don't guess how to install it.
+**Requires `mabl-test-edit`.** If that skill isn't there, stop and say which
+skill is missing — don't attempt the edit yourself, and don't guess how to
+install it, because that depends on how this skill was installed.
 
 **Otherwise** — the fix needs the live app, e.g. "verify the toast appears" for
 an element nothing in the test has ever touched — edit through the authoring

--- a/plugins/mabl/skills/mabl-test-authoring/SKILL.md
+++ b/plugins/mabl/skills/mabl-test-authoring/SKILL.md
@@ -44,8 +44,8 @@ mabl auth info    # verify you're logged in and the token hasn't expired
               (see step 4 — a completed session is not proof)
 ```
 
-You can run multiple planning and authoring sessions concurrently —
-just track the session IDs.
+Multiple planning and authoring sessions can run concurrently — just track
+the session IDs.
 
 ### After authoring completes
 
@@ -67,7 +67,7 @@ to the session; `status` surfaces its id plus a `viewTestRunUrl`. So:
 - **absent** → nothing proved the test works. Either the validation didn't
   pass, or the workspace can't report agent runs. Treat the test as unverified.
 
-Other things you can do with the test:
+Other things to do with the test:
 
 - **Run the test in the cloud:** `mabl tests run-cloud --id <createdTestId>`
 - **Run the test locally:** `mabl tests run --id <createdTestId>`
@@ -123,8 +123,8 @@ for the planner to say it's ready — one call is often enough if the
 intent is specific. Call `--changes` only when the plan is missing
 something.
 
-You can run multiple planning sessions in parallel for different
-tests — each has its own session ID.
+Multiple planning sessions can run in parallel for different tests — each
+has its own session ID.
 
 ---
 
@@ -439,6 +439,10 @@ the `mabl-test-edit` skill's structured-step lane, which applies a named
 
 That lane is not just faster. **A structured insert cannot delete anything**, so
 it removes the whole risk this section is guarding against.
+
+**Confirm `mabl-test-edit` is in your available skills before routing the fix
+there.** If it isn't, stop and tell the user which skill is missing by name —
+don't attempt the edit yourself, and don't guess how to install it.
 
 **Otherwise** — the fix needs the live app, e.g. "verify the toast appears" for
 an element nothing in the test has ever touched — edit through the authoring

--- a/plugins/mabl/skills/mabl-test-authoring/references/validate-and-heal.md
+++ b/plugins/mabl/skills/mabl-test-authoring/references/validate-and-heal.md
@@ -70,9 +70,9 @@ to work around — skip 4.1 and say the structure was not checked.
 mabl agent debug steps <reportedTestRunId> --all --output json
 ```
 
-Pass `--all`. Without it the output filters to failed and recovered steps,
-which on a passing validation run means an empty `steps` array — correct, but
-not what you want here.
+Pass `--all`. Without it the output filters to failed steps, which on a passing
+validation run means an empty `steps` array — correct, but not what you want
+here.
 
 The envelope carries `step_addressing: "index"`, which is how you know this is
 an agent-reported run rather than an ordinary cloud run. Entries look like:

--- a/plugins/mabl/skills/mabl-test-authoring/references/validate-and-heal.md
+++ b/plugins/mabl/skills/mabl-test-authoring/references/validate-and-heal.md
@@ -159,9 +159,10 @@ Note what you do *not* have: these runs capture screenshots only, no DOM
 snapshot. So a descriptor for an element the test never touched has to come from
 a live session — that is the case the agent lane exists for.
 
-When the edit is nameable, hand it to the `mabl-test-edit` skill's
-structured-step lane (`insert_after` / `replace` / `move`). Keep the decision —
-what is missing, and whether a fix weakened the test — in this loop.
+When the edit is nameable, hand it to the structured-step lane
+(`insert_after` / `replace` / `move`) the way step 4.3 describes — that step owns
+the routing, including checking the skill it routes to is there. Keep the
+decision — what is missing, and whether a fix weakened the test — in this loop.
 
 ### The agent lane
 

--- a/plugins/mabl/skills/mabl-test-authoring/references/validate-and-heal.md
+++ b/plugins/mabl/skills/mabl-test-authoring/references/validate-and-heal.md
@@ -60,7 +60,7 @@ Compare that against the number of things your intent asked to verify. If the
 intent named three checks and the test has one assertion, you know what's
 missing before you look at any run.
 
-`export` refuses performance tests and tests that aren't mablscript-backed
+`export` refuses performance tests and mabl's own default tests
 ("Default mabl tests can not be exported"). That is a real limit, not an error
 to work around — skip 4.1 and say the structure was not checked.
 

--- a/plugins/mabl/skills/mabl-test-coverage-design/SKILL.md
+++ b/plugins/mabl/skills/mabl-test-coverage-design/SKILL.md
@@ -32,8 +32,8 @@ mabl auth login --auto   # one-time OAuth in browser — required before any com
 
 You also need the **`chrome-devtools` MCP**, which drives its own real Chrome
 instance, to explore the app during the design phase. Don't use
-`chrome-for-mabl` here — that server is reserved for `mabl-debug`, where it
-attaches to the specific Chrome instance `mabl agent debug session` launches.
+`chrome-for-mabl` here — that server attaches to the specific Chrome instance
+`mabl agent debug session` launches, so it can't drive a browser of its own.
 
 ## The two constraints — fix these before anything else
 
@@ -133,6 +133,10 @@ mabl agent authoring status --session-id <sessionId>
 The `mabl-test-authoring` skill covers this command in depth (the
 `--test-information` fields, API tests, local mode). Use it for the per-test
 detail; this skill owns deciding *which* tests to author and *in what order*.
+
+**Confirm `mabl-test-authoring` is in your available skills before starting the
+fan-out.** If it isn't, stop and tell the user which skill is missing by name —
+don't author the suite without it, and don't guess how to install it.
 
 ### When a session pauses to ask
 
@@ -437,7 +441,7 @@ definition — the same mechanism the mabl web app's "Add reference tests" uses.
 ### Referencing vs copying — two different asks
 
 A reference says *"match this test's conventions."* A copy says *"start from
-this test's actual steps."* They solve different problems and you can use both
+this test's actual steps."* They solve different problems and both apply
 at once:
 
 | | Reference block | Copy |

--- a/plugins/mabl/skills/mabl-test-coverage-design/SKILL.md
+++ b/plugins/mabl/skills/mabl-test-coverage-design/SKILL.md
@@ -134,9 +134,9 @@ The `mabl-test-authoring` skill covers this command in depth (the
 `--test-information` fields, API tests, local mode). Use it for the per-test
 detail; this skill owns deciding *which* tests to author and *in what order*.
 
-**Confirm `mabl-test-authoring` is in your available skills before starting the
-fan-out.** If it isn't, stop and tell the user which skill is missing by name —
-don't author the suite without it, and don't guess how to install it.
+**Requires `mabl-test-authoring`.** If that skill isn't there, stop and say
+which skill is missing — don't author the suite without it, and don't guess how
+to install it, because that depends on how this skill was installed.
 
 ### When a session pauses to ask
 

--- a/plugins/mabl/skills/mabl-test-coverage-design/SKILL.md
+++ b/plugins/mabl/skills/mabl-test-coverage-design/SKILL.md
@@ -458,8 +458,9 @@ suite is copies** and only one test per path is authored cold. Which authored
 test each copy starts from is its own decision — see *The copy graph* below.
 
 Don't let reusable flows talk you out of it. It is tempting to reason "login and
-navigation are already flows, so there's nothing to inherit" — open the test
-you'd copy from with `get_test_definition` and count. The flows cover the
+navigation are already flows, so there's nothing to inherit" — export the test
+you'd copy from (`mabl tests export <testId> --format json --file
+/tmp/source.json`) and count. The flows cover the
 walking about; the steps *between* them are inline, and they are the ones you
 actually want:
 

--- a/plugins/mabl/skills/mabl-test-coverage-design/SKILL.md
+++ b/plugins/mabl/skills/mabl-test-coverage-design/SKILL.md
@@ -464,9 +464,8 @@ test each copy starts from is its own decision — see *The copy graph* below.
 Don't let reusable flows talk you out of it. It is tempting to reason "login and
 navigation are already flows, so there's nothing to inherit" — export the test
 you'd copy from (`mabl tests export <testId> --format json --file
-/tmp/source.json`) and count. The flows cover the
-walking about; the steps *between* them are inline, and they are the ones you
-actually want:
+/tmp/source.json`) and count. The flows cover the walking about; the steps
+*between* them are inline, and they are the ones you actually want:
 
 - the variable setup that names and shapes the subject
   (`Generate a string "editapp-{{digit:6}}"` → `appName`)

--- a/plugins/mabl/skills/mabl-test-edit/SKILL.md
+++ b/plugins/mabl/skills/mabl-test-edit/SKILL.md
@@ -2,22 +2,20 @@
 name: mabl-test-edit
 description: |
   Change a mabl test that already exists — rename it, relabel it,
-  enable/disable it, or edit its steps (replace / insert / delete / move).
-  This skill is mostly a router: it reads the test, then picks the cheapest
-  lane that can make the change deterministically, and only spins up a live
-  browser agent when the change genuinely needs to look at the app.
-  Fire when the user names an existing test (a `*-j` id or a test name) and
-  wants to modify it: "rename this test", "add a label", "disable that test",
-  "delete step 7", "make step 4 wait for the spinner to disappear", "insert a
-  click before the assertion", "change the URL that step 2 opens".
-  For CREATING a new test use mabl-test-authoring; for debugging a FAILING
-  test use mabl-debug. This skill edits a test that already exists.
-  One boundary: if the test was just authored in this session and its own
-  validation found a gap, mabl-test-authoring's validate-and-fix step owns that
-  decision — it holds the authoring intent and the rule against converging by
-  deleting coverage. Don't take the decision over. Do accept the work: that step
-  routes its specifiable fixes here on purpose, because a structured step edit
-  is instant and cannot delete anything.
+  enable/disable it, or edit its steps (replace, insert, delete, move). Reads the
+  test, then routes to the cheapest lane that can make the change
+  deterministically — a live browser agent only when it needs the running app.
+  Fire when the user names an existing test (a `*-j` id or a test name) and wants
+  to modify it: "rename this test", "add a label", "disable that test", "delete
+  step 7", "make step 4 wait for the spinner to disappear", "change the URL that
+  step 2 opens".
+  For CREATING a new test use mabl-test-authoring; for debugging a FAILING test
+  use mabl-debug.
+  One boundary: if the test was just authored this session and its validation
+  found a gap, mabl-test-authoring's validate-and-fix step owns that decision —
+  it holds the authoring intent and the rule against converging by deleting
+  coverage. Don't take the decision over. Do accept the specifiable fixes it
+  routes here: a structured step edit is instant and cannot delete anything.
 allowed-tools: Bash, mcp__mabl__*
 ---
 
@@ -279,15 +277,14 @@ mcp__mabl__mabl_authoring_edit({
 
 This is the only lane that needs a `workspaceId` (the others key off the test or
 flow id). Get it from `mcp__mabl__get_current_user` or
-`mcp__mabl__list_mabl_workspaces` — or reuse the workspace `mabl-init` saved to
-your agent memory.
+`mcp__mabl__list_mabl_workspaces` — or reuse the workspace already saved in your
+agent memory.
 
 Returns `{ sessionId, viewTaskUrl }`. It's an async cloud session (minutes, real
 compute), not a deterministic edit — track it with
 `mcp__mabl__mabl_authoring_status({ sessionId })` and, once it completes,
 verify with `mcp__mabl__run_mabl_test_cloud`. Write the `test_case` the way you
-would for `mabl-test-authoring`: concrete about what to change and what to
-verify.
+would an authoring intent: concrete about what to change and what to verify.
 
 The agent lane runs its **own** branch handling (a `branch` name in
 `testInformation`, resolved server-side), so the Lane 2 confirmation mechanic

--- a/plugins/mabl/skills/mabl-test-edit/SKILL.md
+++ b/plugins/mabl/skills/mabl-test-edit/SKILL.md
@@ -335,5 +335,4 @@ Trainer GUI.
 editor a person drives by hand. It isn't agent-drivable, so this skill doesn't
 use it, but it's the right answer when every automated lane is closed (the
 previews aren't enabled, a legacy flow, or a change too fiddly to describe).
-Mention it to the
-user as the fallback; don't try to script it.
+Mention it to the user as the fallback; don't try to script it.

--- a/plugins/mabl/skills/mabl-test-edit/SKILL.md
+++ b/plugins/mabl/skills/mabl-test-edit/SKILL.md
@@ -39,9 +39,9 @@ mabl auth info    # verify you're logged in and the token hasn't expired
 ```
 
 The metadata and structured-step lanes run entirely on the hosted `mabl` MCP
-server (no local browser). The step lanes are a preview behind a workspace
-feature flag — see [Lane availability](#lane-availability) for what to do when
-they're off.
+server (no local browser). The step lanes are a preview, so they aren't enabled
+in every workspace — see [Lane availability](#lane-availability) for what to do
+when they're off.
 
 ## The router
 
@@ -78,7 +78,7 @@ rather than *the step definition*, it belongs in the agent lane.
 
 ## Lane 1 — Metadata
 
-The always-available lane (no feature flag). One atomic call; a list of
+The always-available lane — every workspace has it. One atomic call; a list of
 operations applied in order, saved in a single PATCH — if any operation is
 invalid, nothing is saved.
 
@@ -189,8 +189,8 @@ mcp__mabl__mabl_get_authoring_guide({ uri: "mabl-author://authoring-patterns" })
 mcp__mabl__mabl_get_schema_resource({ uri: "mabl-schema://step" })
 ```
 
-(Both reference tools live behind the same `mabl_authoring_mcp` flag as the
-step-edit tools, so they're available exactly when Lane 2 is.)
+(Both reference tools ship with the same preview as the step-edit tools, so
+they're available exactly when Lane 2 is.)
 
 Steps are canonicalized on save (e.g. variable aliases are normalized); the
 response reports this under `canonicalization`.
@@ -299,20 +299,19 @@ no-branch agent edit targets the default branch before you start the session.
 
 ## Lane availability
 
-The lanes sit behind different feature flags, so "just fall back to the agent
-lane" isn't always possible. Check what's actually available before promising a
-change:
+The lanes are gated **independently**, so "just fall back to the agent lane"
+isn't always possible — one lane being closed tells you nothing about the other.
+Check what's actually available before promising a change:
 
-| Lane | Flag(s) required | If unavailable |
-|------|------------------|----------------|
-| Metadata | none | always available |
-| Structured step | `mabl_authoring_mcp` | the `edit_mabl_*_steps` tools aren't listed; calling one returns *"Mabl test authoring tools are not enabled for this workspace. Contact mabl support to join the preview."* |
-| Agent | `generative_ai` **and** `agentic_test_editing` | `mabl_authoring_edit` isn't listed / returns a not-enabled error |
+| Lane | If unavailable |
+|------|----------------|
+| Metadata | always available |
+| Structured step | the `edit_mabl_*_steps` tools aren't listed; calling one returns *"Mabl test authoring tools are not enabled for this workspace. Contact mabl support to join the preview."* |
+| Agent | `mabl_authoring_edit` isn't listed / returns a not-enabled error |
 
-Degrade honestly. You can't read a workspace's feature flags — so judge a lane
+Degrade honestly. You can't see which previews a workspace has — so judge a lane
 by what you *can* see: **a lane is open when its tool is in your tool list**, and
-closed when the tool is absent or returns the not-enabled error above. (The flag
-names are just there to explain *why* a tool might be missing.)
+closed when the tool is absent or returns the not-enabled error above.
 
 1. Prefer the structured lane for nameable step edits.
 2. If the `edit_mabl_*_steps` tools aren't in your tool list, the structured

--- a/plugins/mabl/skills/mabl-test-edit/SKILL.md
+++ b/plugins/mabl/skills/mabl-test-edit/SKILL.md
@@ -59,7 +59,7 @@ this tag is the whole routing decision for step edits:
 |--------|------------|------------------|
 | `structural` | steps that live directly in this test | `edit_mabl_test_steps` |
 | `reusable` | a shared flow reused by other tests (carries a `used_by` sample) | `edit_mabl_flow_steps` |
-| `legacy_unsupported` | old mablscript flow | neither — see [Legacy flows](#legacy-and-unsupported-flows) |
+| `legacy_unsupported` | a flow in an older format | neither — see [Legacy flows](#legacy-and-unsupported-flows) |
 
 Pick the lane by the *kind of change*, then confirm the target:
 
@@ -326,7 +326,7 @@ closed when the tool is absent or returns the not-enabled error above.
 
 ## Legacy and unsupported flows
 
-A flow tagged `legacy_unsupported` (older mablscript format) can't be edited by
+A flow tagged `legacy_unsupported` (an older flow format) can't be edited by
 the structured lanes — `edit_mabl_test_steps` returns
 `reason: "wrong_authoring_boundary"` and `edit_mabl_flow_steps` returns
 `reason: "legacy_format_unsupported"`. Route these to the agent lane, or to the

--- a/plugins/mabl/skills/mabl-test-edit/SKILL.md
+++ b/plugins/mabl/skills/mabl-test-edit/SKILL.md
@@ -336,6 +336,7 @@ Trainer GUI.
 
 `mabl tests edit` opens the test in the **Trainer GUI** — an interactive desktop
 editor a person drives by hand. It isn't agent-drivable, so this skill doesn't
-use it, but it's the right answer when every automated lane is closed (preview
-flags off, a legacy flow, or a change too fiddly to describe). Mention it to the
+use it, but it's the right answer when every automated lane is closed (the
+previews aren't enabled, a legacy flow, or a change too fiddly to describe).
+Mention it to the
 user as the fallback; don't try to script it.


### PR DESCRIPTION
These skills were telling readers things they had no way to use.

`mabl-test-edit` had a "Flag(s) required" column naming three internal feature
flags — and then said, two lines later, that an agent can't read a workspace's
flags and has to judge a lane by whether its tool is in the tool list. The names
were unusable by anyone: a customer can't turn a flag on either. That column was
really carrying one useful fact, which is now stated plainly instead: the lanes
are gated independently, so one being closed tells you nothing about the other.
Every observable stays — the tool list, the verbatim "contact mabl support" error,
the Trainer GUI fallback.

`mabl-debug` told you to rebuild the CLI via `build:local` in CLAUDE.md. That's a
script in a repo you don't have, and "CLAUDE.md" reads as your own agent memory
file — a leftover from when these skills lived in mabl-cli. For an app-code fix
the thing to rebuild is the app under test. Four smaller cases were the same
shape: a status described as "TRA-recovered" when the status you actually see is
`recovered`; step-id guidance that branched on whether a flow has persisted
`json_steps` ids, which nothing you can run reports; a pointer at
`get_test_definition`, which is the cloud planner's tool and not yours; and
"mablscript", which named a format where the reader only ever sees the
consequence. Also gone: a promise that the CLI installer would pick something up
later.

The rule underneath all of it — branch only on state the reader can observe. Naming
an internal mechanism beside an observable is fine; branching on one nobody can
check is an instruction that can't be followed.

The second half is CI, because three ways for a skill to break were invisible. A
`name` that doesn't match its folder silently fails to load in Copilot. A
description over 1024 characters gets truncated mid-word by Codex — which
`mabl-test-edit` was hitting at 1201, losing the clause that tells an agent to
accept the fixes authoring routes to it. And frontmatter outside the six spec keys
fails claude.ai upload and the Skills API with a hard error. `validate-skills.mjs`
checks all three. `scripts/validate-template.mjs` is untouched, since it's vendored
from cursor/plugin-template.

Its fourth check is about routing. A skill can be installed on its own, so "hand
this to `mabl-test-edit`" was a dead end for anyone who had only the skill they
were reading. Those hand-offs now confirm the sibling is available and name it when
it isn't. They deliberately don't name an install command — a skill can't know
which of the five surfaces installed it, so `gh skill install ...` is wrong
guidance for the four readers who used a marketplace. The check reads every `.md`
in a skill folder and wants the confirmation in the same file as the mention,
because a reference is loaded on its own; a reference that trips it usually wants
rewording, since routing belongs in SKILL.md.

One caveat worth flagging: `mabl-debug` still says "Runtime recovery is sunset, so
no new run produces this status." The CLI still ships the engine, still invokes it,
and gates it on a server-supplied workspace field that defaults off rather than
being removed — and `mabl tests run --tra-mode` still accepts `off|fail_at_end|pass`.
So that sentence isn't supportable from the code. It's left alone here and needs an
answer from whoever owns the shutdown.